### PR TITLE
Appium updates for Paramedic

### DIFF
--- a/lib/appium/AppiumRunner.js
+++ b/lib/appium/AppiumRunner.js
@@ -102,6 +102,24 @@ function getConfigPath(appPath) {
     return path.join(appPath, 'config.xml');
 }
 
+function installAppiumServer() {
+    /*
+     * We install appium in this counter-intuitive way at runtime in order to
+     * not trigger massive dependency downloads via `npm install` for autotest
+     * execution. Installing appium only happens in the local-running case, and
+     * thus is not needed in our CI system. By using this method, we save the CI
+     * a lot of time.
+     * ALTERNATIVE: what if paramedic dependencies were installed via `npm install
+     * --production`, and appium was stuffed into `devDependencies`. That should
+     * also prevent this problem? 
+     */
+    var installPath = path.join(__dirname, '../..');
+    logger.normal('paramedic-appium: Installing Appium server to ' + installPath);
+    shell.pushd(installPath);
+    return execPromise('npm install appium@1.5.3').then(function () {
+        shell.popd();
+    });
+}
 function addCspSource(appPath, directive, source) {
     var cspInclFile = path.join(appPath, 'www/csp-incl.js');
     var indexFile = path.join(appPath, 'www/index.html');
@@ -453,7 +471,8 @@ AppiumRunner.prototype.runTests = function (useSauce) {
         if (!useSauce) {
             logger.normal('Running tests locally - starting appium & ios proxy as needed.');
             self.startIosProxy();
-            return Q().then(self.startAppiumServer.bind(self));
+            return installAppiumServer()
+                .then(self.startAppiumServer.bind(self));
         }
     })
     .then(self.startTests.bind(self))

--- a/lib/appium/AppiumRunner.js
+++ b/lib/appium/AppiumRunner.js
@@ -194,15 +194,6 @@ function killProcess(procObj, callback) {
     }
 }
 
-function installAppiumServer() {
-    var installPath = path.join(__dirname, '../..');
-    logger.normal('paramedic-appium: Installing Appium server to ' + installPath);
-    shell.pushd(installPath);
-    return execPromise('npm install appium').then(function () {
-        shell.popd();
-    });
-}
-
 AppiumRunner.prototype.createScreenshotDir = function () {
     util.mkdirSync(this.options.screenshotPath);
 };
@@ -336,8 +327,7 @@ AppiumRunner.prototype.startAppiumServer = function () {
     appiumServerCommand = 'node ' + APPIUM_SERVER_PATH + additionalArgs;
 
     // run the Appium server
-    logger.normal('paramedic-appium: Running:');
-    logger.normal('paramedic-appium: ' + appiumServerCommand);
+    logger.normal('paramedic-appium: Running appium w/ ' + appiumServerCommand);
     self.appium.alive = true;
     self.appium.process = child_process.exec(appiumServerCommand, { maxBuffer: BIG_BUFFER_SIZE }, function (error) {
         logger.normal('paramedic-appium: Appium process exited.');
@@ -355,6 +345,9 @@ AppiumRunner.prototype.startAppiumServer = function () {
 
     // Wait for the Appium server to start up
     self.appium.process.stdout.on('data', function (data) {
+        if (global.VERBOSE) {
+            logger.normal('Appium: ' + data);
+        }
         if (data.indexOf('Appium REST http interface listener started') > -1) {
             d.resolve();
         }
@@ -407,7 +400,6 @@ AppiumRunner.prototype.setGlobals = function () {
     global.SAUCE_USER = this.options.sauceUser;
     global.SAUCE_KEY = this.options.sauceKey;
     global.SAUCE_CAPS = this.options.sauceCaps;
-    global.VERBOSE = this.options.verbose;
     global.SAUCE_SERVER_HOST = util.SAUCE_HOST;
     global.SAUCE_SERVER_PORT = util.SAUCE_PORT;
 };
@@ -419,8 +411,9 @@ AppiumRunner.prototype.prepareApp = function () {
     var deviceString = self.options.device ? ' --device' : '';
     var buildCommand = 'cordova build ' + self.options.platform + deviceString;
 
+    // TODO: is removing medic.json still needed?
     // remove medic.json and (re)build
-    shell.rm(path.join(fullAppPath, 'www', 'medic.json'));
+    shell.rm('-f', path.join(fullAppPath, 'www', 'medic.json'));
     fs.stat(fullAppPath, function (error, stats) {
         // check if the app exists
         if (error || !stats.isDirectory()) {
@@ -458,9 +451,9 @@ AppiumRunner.prototype.runTests = function (useSauce) {
 
     return Q().then(function () {
         if (!useSauce) {
+            logger.normal('Running tests locally - starting appium & ios proxy as needed.');
             self.startIosProxy();
-            return installAppiumServer()
-            .then(self.startAppiumServer.bind(self));
+            return Q().then(self.startAppiumServer.bind(self));
         }
     })
     .then(self.startTests.bind(self))

--- a/lib/appium/AppiumRunner.js
+++ b/lib/appium/AppiumRunner.js
@@ -429,8 +429,14 @@ AppiumRunner.prototype.prepareApp = function () {
     var deviceString = self.options.device ? ' --device' : '';
     var buildCommand = 'cordova build ' + self.options.platform + deviceString;
 
-    // TODO: is removing medic.json still needed?
-    // remove medic.json and (re)build
+    /*
+     * We use medic.json to pass the local medic server URI to the paramedic
+     * plugin so it can report test results back to paramedic. We remove it
+     * before the Appium run so the test framework plugin won't start plugin
+     * tests right away.
+     * So, basically this is needed to run Appium tests without running other
+     * plugin tests simultaneously.
+     */
     shell.rm('-f', path.join(fullAppPath, 'www', 'medic.json'));
     fs.stat(fullAppPath, function (error, stats) {
         // check if the app exists

--- a/lib/appium/helpers/wdHelper.js
+++ b/lib/appium/helpers/wdHelper.js
@@ -72,7 +72,6 @@ module.exports.getDriver = function (platform) {
         };
 
         driverConfig = {
-            browserName: '',
             platformName: normalizedPlatform,
             platformVersion: global.PLATFORM_VERSION || '',
             deviceName: global.DEVICE_NAME || '',

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -271,9 +271,13 @@ ParamedicRunner.prototype.runLocalTests = function () {
     })
     .then(function(command) {
         self.setPermissions();
-        logger.normal('cordova-paramedic: running command ' + command);
 
-        return execPromise(command);
+        if (!self.config.runMainTests()) {
+            return;
+        } else {
+            logger.normal('cordova-paramedic: running command ' + command);
+            return execPromise(command);
+        }
     })
     .then(function() {
         // skipping here and not at the beginning because we need to

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -280,8 +280,6 @@ ParamedicRunner.prototype.runLocalTests = function () {
         }
     })
     .then(function() {
-        // skipping here and not at the beginning because we need to
-        // start up the Android emulator for Appium tests to run on
         if (!self.config.runMainTests()) {
             logger.normal('Skipping main tests...');
             return util.TEST_PASSED;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "wd": "^0.4.0"
   },
   "devDependencies": {
-    "jasmine-node": "~1",
-    "jshint": "^2.6.0"
+    "jshint": "^2.6.0",
+    "appium": "1.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "wd": "^0.4.0"
   },
   "devDependencies": {
-    "jshint": "^2.6.0",
-    "appium": "1.5.3"
+    "jshint": "^2.6.0"
   }
 }


### PR DESCRIPTION
Please review @purplecabbage and @alsorokin!

A lot of these changes are ports from my now-defunct medic pull request: https://github.com/apache/cordova-medic/pull/106

### Platforms affected

Android and iOS in particular, as those are the only platforms being UI-tested in an automated fashion at this time.

### What does this PR do?

From most-impactful to least:

1. Set appium as a devDependency, and remove shelling out to `npm` to install it. This lets us control appium's version using `package.json`, which is the standard node.js way to do that. This is important as the latest published version of appium does not work!
2. When running with the `--skipMainTests` flag, prevent the app-under-test from being built twice. The AUT is different for the autotests vs. the appium UI tests, and thus needs separate compilations. This changes saves on an extra compilation in this scenario.
3. When the `--verbose` flag is provided, and we are running appium locally, also log out appium stdout to paramedic stdout.
4. Remove `jasmine-node` module. I don't think it is used?
4. Remove unnecessary `browserName` capability from those being passed to appium.
5. Added a TODO around removing the `medic.json` file that is supposed to be part of the app. I think this is a remnant from how medic worked. I am not sure it is still applicable. Also, remove the file with the `-f` flag, so in case it does not exist, do not error about it.
6. Removed duplicate setting of `global.VERBOSE`.

### What testing has been done on this change?

Ran locally on an Android 5.1 emulator.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
