### PR TITLE
[CB-12210] require a string when parsing the plugin argument.

### DIFF
--- a/main.js
+++ b/main.js
@@ -60,7 +60,9 @@ var USAGE           = "Error missing args. \n" +
     "--ci : (optional) Skip tests that require user interaction\n" +
     "";
 
-var argv = parseArgs(process.argv.slice(2));
+var argv = parseArgs(process.argv.slice(2), {
+    "string": ["plugin"]
+});
 var pathToParamedicConfig = argv.config && path.resolve(argv.config);
 
 if (pathToParamedicConfig || // --config


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

Please review @purplecabbage & @sterlingann.

### Platforms affected

All.

### What does this PR do?

A bit friendlier error messaging when providing an invalid `--plugin` flag. Fixes [CB-12210](https://issues.apache.org/jira/browse/CB-12210) which was filed by @sterlingann.

### What testing has been done on this change?

Before the change:

```
➔ node cordova-paramedic/main.js --platform android --plugin
cordova-paramedic: creating temp project at /var/folders/sp/5jj48bd57sx78cnldkk5ch_h0000gn/T/tmp-49414mdpFuISIeWQF
/private/var/folders/sp/5jj48bd57sx78cnldkk5ch_h0000gn/T/tmp-49414mdpFuISIeWQF /Users/maj/src
cordova-paramedic: installing plugins
Completed tests at 8:32:32 PM
Collecting logs for the devices.
It looks like there is no target to get logs from.
Uninstalling the app.
TypeError: plugin.indexOf is not a function
    at PluginsManager.installSinglePlugin (/Users/maj/src/cordova-paramedic/lib/PluginsManager.js:63:28)
    at PluginsManager.installPlugins (/Users/maj/src/cordova-paramedic/lib/PluginsManager.js:36:14)
    at ParamedicRunner.installPlugins (/Users/maj/src/cordova-paramedic/lib/paramedic.js:141:25)
    at ParamedicRunner.prepareProjectToRunTests (/Users/maj/src/cordova-paramedic/lib/paramedic.js:130:10)
    at /Users/maj/src/cordova-paramedic/lib/paramedic.js:76:21
    at _fulfilled (/Users/maj/src/cordova-paramedic/node_modules/q/q.js:834:54)
    at self.promiseDispatch.done (/Users/maj/src/cordova-paramedic/node_modules/q/q.js:863:30)
    at Promise.promise.promiseDispatch (/Users/maj/src/cordova-paramedic/node_modules/q/q.js:796:13)
    at /Users/maj/src/cordova-paramedic/node_modules/q/q.js:857:14
    at runSingle (/Users/maj/src/cordova-paramedic/node_modules/q/q.js:137:13)
```

After the change:

```
➔ node cordova-paramedic/main.js --platform android --plugin
Error missing args.
cordova-paramedic --platform PLATFORM --plugin PATH [--justbuild --timeout MSECS --startport PORTNUM --endport PORTNUM --browserify]
`PLATFORM` : the platform id. Currently supports 'ios', 'browser', 'windows', 'android', 'wp8'.
	Path to platform can be specified as link to git repo like:
	windows@https://github.com/apache/cordova-windows.git
	or path to local copied git repo like:
	windows@../cordova-windows/
`PATH` : the relative or absolute path to a plugin folder
	expected to have a 'tests' folder.
	You may specify multiple --plugin flags and they will all
	be installed and tested together.
`MSECS` : (optional) time in millisecs to wait for tests to pass|fail
	(defaults to 10 minutes)
`PORTNUM` : (optional) ports to find available and use for posting results from emulator back to paramedic server(default is from 8008 to 8009)
--target : (optional) target to deploy to
--justbuild : (optional) just builds the project, without running the tests
--browserify : (optional) plugins are browserified into cordova.js
--verbose : (optional) verbose mode. Display more information output
--useTunnel: (optional) use tunneling instead of local address. default is false
--config : (optional) read configuration from paramedic configuration file
--outputDir : (optional) path to save Junit results file & Device logs
--cleanUpAfterRun : (optional) cleans up the application after the run
--logMins : (optional) Windows only - specifies number of minutes to get logs
--tccDb : (optional) iOS only - specifies the path for the TCC.db file to be copied.
--shouldUseSauce : (optional) run tests on Saucelabs
--buildName : (optional) Build name to show in Saucelabs dashboard
--sauceUser : (optional) Saucelabs username
--sauceKey : (optional) Saucelabs access key
--sauceDeviceName : (optional) Name of the SauceLabs emulator. For example, "iPhone Simulator"
--saucePlatformVersion : (optional) Platform version of the SauceLabs emulator. For example, "9.3"
--sauceAppiumVersion : (optional) Appium version to use when running on Saucelabs. For example, "1.5.3"
--skipMainTests : (optional) Do not run main (cordova-test-framework) tests
--skipAppiumTests : (optional) Do not run Appium tests
--ci : (optional) Skip tests that require user interaction
```

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

