### PR TITLE
CB-11473: add a `--version` flag, which will just print the version f…

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,7 +25,7 @@ var paramedic       = require('./lib/paramedic');
 var ParamedicConfig = require('./lib/ParamedicConfig');
 
 var USAGE           = "Error missing args. \n" +
-    "cordova-paramedic --platform PLATFORM --plugin PATH [--justbuild --timeout MSECS --startport PORTNUM --endport PORTNUM --browserify]\n" +
+    "cordova-paramedic --platform PLATFORM --plugin PATH [--justbuild --timeout MSECS --startport PORTNUM --endport PORTNUM --browserify --version]\n" +
     "`PLATFORM` : the platform id. Currently supports 'ios', 'browser', 'windows', 'android', 'wp8'.\n" +
                     "\tPath to platform can be specified as link to git repo like:\n" +
                     "\twindows@https://github.com/apache/cordova-windows.git\n" +
@@ -38,6 +38,7 @@ var USAGE           = "Error missing args. \n" +
     "`MSECS` : (optional) time in millisecs to wait for tests to pass|fail \n" +
               "\t(defaults to 10 minutes) \n" +
     "`PORTNUM` : (optional) ports to find available and use for posting results from emulator back to paramedic server(default is from 8008 to 8009)\n" +
+    "--version : (optional) prints cordova-paramedic version and exits\n" +
     "--target : (optional) target to deploy to\n" +
     "--justbuild : (optional) just builds the project, without running the tests \n" +
     "--browserify : (optional) plugins are browserified into cordova.js \n" +
@@ -63,7 +64,10 @@ var USAGE           = "Error missing args. \n" +
 var argv = parseArgs(process.argv.slice(2));
 var pathToParamedicConfig = argv.config && path.resolve(argv.config);
 
-if (pathToParamedicConfig || // --config
+if (argv.version) {
+    console.log(require('./package.json')['version']);
+    process.exit(0);
+} else if (pathToParamedicConfig || // --config
     argv.platform && argv.plugin) { // or --platform and --plugin
 
     var paramedicConfig = pathToParamedicConfig ?


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

Please review @purplecabbage and @shazron.

### Platforms affected

All.

### What does this PR do?

Adds a `--version` flag that prints out the version from package.json, then exits. Originally filed by @shazron in [CB-11473](https://issues.apache.org/jira/browse/CB-11473).

Just doin' a little JIRA cleaning ;)

### What testing has been done on this change?

Tested from a Mac OS 10.11 terminal w/ node.js 6.9.1.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.