### PR TITLE
Fix Android paths to new structure

### DIFF
--- a/lib/appium/AppiumRunner.js
+++ b/lib/appium/AppiumRunner.js
@@ -75,7 +75,7 @@ function getPackagePath(options) {
 
     switch (options.platform) {
     case 'android':
-        var packagePath = path.join(fullAppPath, '/platforms/android/build/outputs/apk/android-debug.apk');
+        var packagePath = path.join(fullAppPath, '/platforms/android/app/build/outputs/apk/debug/app-debug.apk');
         if (fs.existsSync(packagePath)) {
             return packagePath;
         }

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -651,7 +651,7 @@ ParamedicRunner.prototype.getPackageFolder = function () {
     var packageFolder;
     switch (this.config.getPlatformId()) {
         case util.ANDROID:
-            packageFolder = path.join(this.tempFolder.name, 'platforms/android/build/outputs/apk/');
+            packageFolder = path.join(this.tempFolder.name, 'platforms/android/app/build/outputs/apk');
             break;
         case util.IOS:
             packageFolder = path.join(this.tempFolder.name, 'platforms/ios/build/emulator/');
@@ -681,7 +681,7 @@ ParamedicRunner.prototype.getBinaryDir = function () {
     var binaryPath;
     switch (this.config.getPlatformId()) {
         case util.ANDROID:
-            binaryPath = path.join(this.tempFolder.name, 'platforms/android/build/outputs/apk');
+            binaryPath = path.join(this.tempFolder.name, 'platforms/android/app/build/outputs/apk');
             break;
         case util.IOS:
             binaryPath = path.join(this.tempFolder.name, 'platforms/ios/build/emulator/');


### PR DESCRIPTION
Cordova Android 7 changed the project structure, so the travis tests are failing.

They are also failing because of unaccepted licenses, I've fixed it in vibration plugin https://github.com/apache/cordova-plugin-vibration/pull/65

Not really sure if I fixed them correctly as I wasn't able to test paramedic locally