### PR TITLE
Support Android devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,14 @@ iOS only parameter. The path to the sample TCC DB file, with permissions, to be 
 cordova-paramedic --platform ios --plugin cordova-plugin-contacts --tccDbPath tcc.db
 ```
 
+#### `--target` (optional)
+
+Android only parameter. The device ID (from `adb devices`) of a device the tests should be run on.
+
+```
+cordova-paramedic --platform android --plugin cordova-plugin-contacts --target 02e7f7e9215da7f8
+```
+
 ### Sauce-only arguments
 
 #### `--shouldUseSauce` (optional)

--- a/lib/ParamedicTargetChooser.js
+++ b/lib/ParamedicTargetChooser.js
@@ -53,6 +53,14 @@ ParamedicTargetChooser.prototype.chooseTarget = function (emulator, target) {
 
 ParamedicTargetChooser.prototype.chooseTargetForAndroid = function (emulator, target) {
     logger.info('cordova-paramedic: Choosing Target for Android');
+
+    if (target) {
+        logger.info('cordova-paramedic: Target defined as: ' + target);
+        var obj = {};
+        obj.target = target;
+        return obj;
+    } 
+    
     return this.startAnAndroidEmulator(target).then(function(emulatorId) {
         var obj = {};
         obj.target = emulatorId;


### PR DESCRIPTION
With this minor change I could run on a physical device by passing the device id with the --target parameter.