### PR TITLE
Fix jshint errors

### DIFF
--- a/lib/ParamedicConfig.js
+++ b/lib/ParamedicConfig.js
@@ -137,7 +137,7 @@ ParamedicConfig.prototype.getArgs = function () {
 
 ParamedicConfig.prototype.setArgs = function (args) {
     this._config.args = args;
-}
+};
 
 ParamedicConfig.prototype.getPlatformId = function () {
     return this._config.platform.split('@')[0];
@@ -252,7 +252,7 @@ ParamedicConfig.prototype.setSkipAppiumTests = function (skipAppiumTests) {
 
 ParamedicConfig.prototype.isBrowserify = function () {
     return this.getArgs().indexOf(BROWSERIFY_ARG) >= 0;
-}
+};
 
 ParamedicConfig.prototype.setBrowserify = function (browserify) {
     if (browserify) {
@@ -260,7 +260,7 @@ ParamedicConfig.prototype.setBrowserify = function (browserify) {
     } else {
         this._config.args = this._config.args.replace(BROWSERIFY_ARG, '');
     }
-}
+};
 
 ParamedicConfig.prototype.getPorts = function () {
     return {
@@ -307,21 +307,21 @@ ParamedicConfig.prototype.setTarget = function (target) {
 
 ParamedicConfig.prototype.getFileTransferServer = function () {
     return this._config.fileTransferServer;
-}
+};
 
 ParamedicConfig.prototype.setFileTransferServer = function (server) {
     this._config.fileTransferServer = server;
-}
+};
 
 ParamedicConfig.prototype.getCli = function () {
     if (this._config.cli) {
         return this._config.cli;
     }
     return DEFAULT_CLI;
-}
+};
 
 ParamedicConfig.prototype.setCli = function (cli) {
     this._config.cli = cli;
-}
+};
 
 module.exports = ParamedicConfig;

--- a/lib/appium/AppiumRunner.js
+++ b/lib/appium/AppiumRunner.js
@@ -82,7 +82,7 @@ function getPackagePath(options) {
             if (fs.existsSync(p)) {
                 packagePath = p;
                 return;
-            };
+            }
         });
         if (packagePath != null) {
             return packagePath;

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -123,7 +123,7 @@ ParamedicRunner.prototype.checkConfig = function () {
         throw new Error('No tests to run: both --skipAppiumTests and --skipMainTests are used');
     }
     checkCli: {
-        if (!(this.config.getCli() === 'cordova') && !(this.config.getCli() === 'phonegap')) {
+        if (this.config.getCli() !== 'cordova' && this.config.getCli() !== 'phonegap') {
             if (path.isAbsolute(this.config.getCli())) {
                 break checkCli;
             }
@@ -329,7 +329,7 @@ ParamedicRunner.prototype.runLocalTests = function () {
         self.setPermissions();
         logger.normal('cordova-paramedic: running command ' + command);
 
-        if (!self.config.getPlatformId() === util.BROWSER) {
+        if (self.config.getPlatformId() !== util.BROWSER) {
             return execPromise(command);
         }
         runProcess = cp.exec(command, function () {

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -664,7 +664,7 @@ ParamedicRunner.prototype.getPackageFolder = function () {
         return foundDir;
     }
     throw new Error ('Couldn\'t locate a built app directory. Looked here: ' + packageDirs);
-}
+};
 
 ParamedicRunner.prototype.getPackageFolders = function () {
     var packageFolders;
@@ -886,7 +886,7 @@ ParamedicRunner.prototype.connectSauceConnect = function () {
     }
 
     return Q.Promise(function (resolve, reject) {
-        logger.info('cordova-paramedic: Starting Sauce Connect...')
+        logger.info('cordova-paramedic: Starting Sauce Connect...');
         sauceConnectLauncher({
             username: self.config.getSauceUser(),
             accessKey: self.config.getSauceKey(),


### PR DESCRIPTION
Run `npm t` showed a list of obvious jshint errors that were simple enough to fix:

```
lib\appium\AppiumRunner.js: line 85, col 14, Unnecessary semicolon.

lib\paramedic.js: line 126, col 13, Confusing use of '!'.
lib\paramedic.js: line 126, col 54, Confusing use of '!'.
lib\paramedic.js: line 332, col 13, Confusing use of '!'.
lib\paramedic.js: line 667, col 2, Missing semicolon.
lib\paramedic.js: line 889, col 68, Missing semicolon.

lib\ParamedicConfig.js: line 140, col 2, Missing semicolon.
lib\ParamedicConfig.js: line 255, col 2, Missing semicolon.
lib\ParamedicConfig.js: line 263, col 2, Missing semicolon.
lib\ParamedicConfig.js: line 310, col 2, Missing semicolon.
lib\ParamedicConfig.js: line 314, col 2, Missing semicolon.
lib\ParamedicConfig.js: line 321, col 2, Missing semicolon.
lib\ParamedicConfig.js: line 325, col 2, Missing semicolon.

lib\PluginsManager.js: line 82, col 61, Missing semicolon.
```

Please double check that I didn't mess up the conversion of the "confusing ! usage".