### PR TITLE
Remove npm script for wp8, add for browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test-android": "node main.js --platform android --plugin ./spec/testable-plugin/",
     "test-ios": "node main.js --platform ios --plugin ./spec/testable-plugin/ --verbose",
     "test-windows": "node main.js --platform windows --plugin ./spec/testable-plugin/",
-    "test-wp8": "node main.js --platform wp8 --plugin ./spec/testable-plugin/"
+    "test-browser": "node main.js --platform browser --plugin ./spec/testable-plugin/"
   },
   "keywords": [
     "cordova",

--- a/spec/build-fail-plugin/package.json
+++ b/spec/build-fail-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "build-fail-plugin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": ""
+}

--- a/spec/build-success-plugin/package.json
+++ b/spec/build-success-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "build-success-plugin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": ""
+}

--- a/spec/sh-read-input-plugin/package.json
+++ b/spec/sh-read-input-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sh-read-input-plugin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": ""
+}

--- a/spec/testable-plugin/package.json
+++ b/spec/testable-plugin/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "testable-plugin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": ""
+}

--- a/spec/testable-plugin/tests/package.json
+++ b/spec/testable-plugin/tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "tests",
+  "version": "1.0.0",
+  "description": "",
+  "main": "tests.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": ""
+}


### PR DESCRIPTION
No need to be able to quickly test wp8 here any more, but being able to test browser (no platform setup at all!) is useful.

(currently includes #34 (so I could actually run this), which will go away after this is merged to master)