### PR TITLE
Fix inappbrowser on Android 7

### DIFF
--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -988,7 +988,7 @@ ParamedicRunner.prototype.runSauceTests = function () {
         // skip permission buster for splashscreen plugin
         // it hangs the test run on Android 7 for some reason
         for (var i = 0; i < plugins.length; i++) {
-            if (plugins[i].indexOf('cordova-plugin-splashscreen') >= 0) {
+            if (plugins[i].indexOf('cordova-plugin-splashscreen') >= 0 || plugins[i].indexOf('cordova-plugin-inappbrowser') >= 0) {
                 skipBuster = true;
             }
         }

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -984,17 +984,20 @@ ParamedicRunner.prototype.runSauceTests = function () {
 
         var platform = self.config.getPlatformId();
         var plugins = self.config.getPlugins();
+
         var skipBuster = false;
-        // skip permission buster for splashscreen plugin
+        // skip permission buster for splashscreen and inappbrowser plugins
         // it hangs the test run on Android 7 for some reason
         for (var i = 0; i < plugins.length; i++) {
             if (plugins[i].indexOf('cordova-plugin-splashscreen') >= 0 || plugins[i].indexOf('cordova-plugin-inappbrowser') >= 0) {
                 skipBuster = true;
             }
         }
+        // always skip buster for browser platform
         if (platform === util.BROWSER) {
             skipBuster = true;
         }
+
         if (!self.config.getUseTunnel()) {
             var polling = false;
             pollForResults = setInterval(function () {


### PR DESCRIPTION
Android 7.0 tests were failing for `cordova-plugin-inappbrowser`: https://github.com/apache/cordova-plugin-inappbrowser/issues/307 Long research showed that this had to do with the permission buster hanging.

Lo and behold, here we have code for not make a plugin hang on Android 7.
Let's add the inappbrowser plugin to this check and see if this fixes things.

Closes https://github.com/apache/cordova-plugin-inappbrowser/issues/307