### PR TITLE
[GH-38] execute launching app and waiting results in parallel

### DIFF
--- a/debug-mode-plugin/scripts/disable-debug-mode.js
+++ b/debug-mode-plugin/scripts/disable-debug-mode.js
@@ -19,7 +19,7 @@
 
 module.exports = function (context) {
     var path = require('path');
-    var shell = context.requireCordovaModule('shelljs');
+    var shell = require('shelljs');
 
     var libPath        = path.resolve(context.opts.projectRoot, "platforms/windows/cordova/lib");
     var appUtilsPath   = path.join(libPath, "WindowsStoreAppUtils.ps1");

--- a/debug-mode-plugin/scripts/enable-debug-mode.js
+++ b/debug-mode-plugin/scripts/enable-debug-mode.js
@@ -19,7 +19,7 @@
 
 module.exports = function (context) {
     var path = require('path');
-    var shell = context.requireCordovaModule('shelljs');
+    var shell = require('shelljs');
 
     var libPath        = path.resolve(context.opts.projectRoot, "platforms/windows/cordova/lib");
     var appUtilsPath   = path.join(libPath, "WindowsStoreAppUtils.ps1");

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -327,35 +327,45 @@ ParamedicRunner.prototype.runLocalTests = function () {
     })
     .then(function(command) {
         self.setPermissions();
-        logger.normal('cordova-paramedic: running command ' + command);
 
-        if (self.config.getPlatformId() !== util.BROWSER) {
-            return execPromise(command);
-        }
-        runProcess = cp.exec(command, function () {
-            // a precaution not to try to kill some other process
-            runProcess = null;
-        });
+        return Q.all(
+          [
+            Q().then(function () {
+              logger.normal('cordova-paramedic: running command ' + command);
+
+              if (self.config.getPlatformId() !== util.BROWSER) {
+                  return execPromise(command);
+              }
+              runProcess = cp.exec(command, function () {
+                  // a precaution not to try to kill some other process
+                  runProcess = null;
+              });
+            }),
+            Q().then(function () {
+              // skipping here and not at the beginning because we need to
+              // start up the Android emulator for Appium tests to run on
+              if (!self.config.runMainTests()) {
+                  logger.normal('Skipping main tests...');
+                  return util.TEST_PASSED;
+              }
+
+              // skip tests if it was just build
+              if (self.shouldWaitForTestResult()) {
+                  return Q.promise(function(resolve, reject) {
+                      // reject if timed out
+                      self.waitForConnection().catch(reject);
+                      // resolve if got results
+                      self.waitForTests().then(resolve);
+                  });
+              }
+
+              return util.TEST_PASSED; // if we're not waiting for a test result, just report tests as passed
+            })
+          ]
+        );
     })
-    .then(function() {
-        // skipping here and not at the beginning because we need to
-        // start up the Android emulator for Appium tests to run on
-        if (!self.config.runMainTests()) {
-            logger.normal('Skipping main tests...');
-            return util.TEST_PASSED;
-        }
-
-        // skip tests if it was just build
-        if (self.shouldWaitForTestResult()) {
-            return Q.promise(function(resolve, reject) {
-                // reject if timed out
-                self.waitForConnection().catch(reject);
-                // resolve if got results
-                self.waitForTests().then(resolve);
-            });
-        }
-
-        return util.TEST_PASSED; // if we're not waiting for a test result, just report tests as passed
+    .then(function(results) {
+      return results[1];
     })
     .fin(function (result) {
         if (runProcess) {
@@ -829,7 +839,7 @@ ParamedicRunner.prototype.getSauceCaps = function () {
             caps.version = this.config.getSaucePlatformVersion() || '45.0';
             caps.platform = caps.browserName.indexOf('Edge') > 0 ? 'Windows 10' : 'macOS 10.13';
             // setting from env.var here and not in the config
-            // because for any other platform we don't need to put the sauce connect up 
+            // because for any other platform we don't need to put the sauce connect up
             // unless the tunnel id is explicitly passed (means that user wants it anyway)
             if (!caps.tunnelIdentifier && process.env[util.SAUCE_TUNNEL_ID_ENV_VAR]) {
                 caps.tunnelIdentifier = process.env[util.SAUCE_TUNNEL_ID_ENV_VAR];


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All platforms (tests only)
Main target is Windows 10.

### What does this PR do?

Fix #38 .

In `runLocalTests` following tasks are called in order.

1. launching test application
2. waiting application test results 

However sometimes jasmine tests in application are finished before wating test results in cordova-paramedic. At least I met this issue in Windows 10. (Please see #38)

After this PR,  these two tasks are called in parallel.
Then the cordova-paramedic can detect jasmine tests results normally. 

### What testing has been done on this change?
In my local PC (Windows 10),
```
npm run test-windows
```
(with Windows Loopback Exemption Manager as mentioned https://github.com/apache/cordova-paramedic#windows-quirks )

This test fails in appveyor.
That is another issue reported #37

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
