### PR TITLE
Updated ParamedicKill.js to support qemu-system-x86_64

### DIFF
--- a/lib/ParamedicKill.js
+++ b/lib/ParamedicKill.js
@@ -65,7 +65,7 @@ ParamedicKill.prototype.tasksOnPlatform = function (platformName) {
         if (util.isWindows()) {
             tasks = ['emulator-arm.exe', 'qemu-system-i386.exe'];
         } else {
-            tasks = ['emulator64-x86', 'emulator64-arm', 'qemu-system-i386'];
+            tasks = ['emulator64-x86', 'emulator64-arm', 'qemu-system-i386', 'qemu-system-x86_64'];
         }
         break;
     case util.BROWSER:


### PR DESCRIPTION
### Platforms affected
Android

### What does this PR do?
Kills 64bit emulator on Mojave

### What testing has been done on this change?
OSX Mojave, Emulator 28.0.16,  system-images;android-28;google_apis;x86


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
