### PR TITLE
add build flag to iOS test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test-appveyor": "npm run test-browser",
     "test-travis": "npm run jshint & npm run test-ios",
     "test-android": "node main.js --platform android --plugin ./spec/testable-plugin/",
-    "test-ios": "node main.js --platform ios --plugin ./spec/testable-plugin/ --verbose",
+    "test-ios": "node main.js --platform ios --plugin ./spec/testable-plugin/ --args=--buildFlag='-UseModernBuildSystem=0' --verbose",
     "test-windows": "node main.js --platform windows --plugin ./spec/testable-plugin/",
     "test-browser": "node main.js --platform browser --plugin ./spec/testable-plugin/"
   },


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
Fixes the test command in `package.json`

### What testing has been done on this change?
Successfull run of `npm test` locally
