### PR TITLE
add documentation for --args command line parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,14 @@ iOS only parameter. The path to the sample TCC DB file, with permissions, to be 
 cordova-paramedic --platform ios --plugin cordova-plugin-contacts --tccDbPath tcc.db
 ```
 
+#### `--args` (optional)
+
+Add additional parameters to the `cordova build` and `cordova run` commands.
+
+```
+cordova-paramedic --platform ios --plugin cordova-plugin-contacts --args=--buildFlag='-UseModernBuildSystem=0'
+```
+
 ### Sauce Labs
 
 #### `--shouldUseSauce` (optional)

--- a/main.js
+++ b/main.js
@@ -64,6 +64,7 @@ var USAGE           = "Error missing args. \n" +
     "--timeout `MSECS` : (optional) time in millisecs to wait for tests to pass|fail \n" +
                 "\t(defaults to 10 minutes) \n" +
     "--useTunnel: (optional) use tunneling instead of local address. default is false\n" +
+    "--args: (optional) add command line args to the \"cordova build\" and \"cordov run\" commands \\n" +
     "--verbose : (optional) verbose mode. Display more information output\n" +
     "--version : (optional) prints cordova-paramedic version and exits\n" +
     "";


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Docs

### What does this PR do?
Documents parameter `--args` which can be used to pass parameters to `cordova build` command. Crucial for fixing the error with the new Xcode build system

Fixes #92
