### PR TITLE
Replace requireCordovaModule with require

### DIFF
--- a/debug-mode-plugin/scripts/disable-debug-mode.js
+++ b/debug-mode-plugin/scripts/disable-debug-mode.js
@@ -19,7 +19,7 @@
 
 module.exports = function (context) {
     var path = require('path');
-    var shell = context.requireCordovaModule('shelljs');
+    var shell = require('shelljs');
 
     var libPath        = path.resolve(context.opts.projectRoot, "platforms/windows/cordova/lib");
     var appUtilsPath   = path.join(libPath, "WindowsStoreAppUtils.ps1");

--- a/debug-mode-plugin/scripts/enable-debug-mode.js
+++ b/debug-mode-plugin/scripts/enable-debug-mode.js
@@ -19,7 +19,7 @@
 
 module.exports = function (context) {
     var path = require('path');
-    var shell = context.requireCordovaModule('shelljs');
+    var shell = require('shelljs');
 
     var libPath        = path.resolve(context.opts.projectRoot, "platforms/windows/cordova/lib");
     var appUtilsPath   = path.join(libPath, "WindowsStoreAppUtils.ps1");


### PR DESCRIPTION
### Platforms affected
none

### Motivation and Context
Fixes: #108

### Description
Replaced `requireCordovaModule` with `require`

### Testing

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
