### PR TITLE
fixes #111 by calling `paramedicSauceLabs.displaySauceDetails` when the action is `build`

### DIFF
--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -105,18 +105,21 @@ ParamedicRunner.prototype.run = function () {
         logger.normal('Completed tests at ' + (new Date()).toLocaleTimeString());
         // if we do --justbuild  or run on sauce,
         // we should NOT do actions below
-        if (self.config.getAction() !== 'build' && !self.config.shouldUseSauce()) {
-            // collect logs and uninstall app
-            self.collectDeviceLogs();
-            return self.uninstallApp()
-                .fail(function () {
-                    // do not fail if uninstall fails
-                })
-                .fin(function () {
-                    self.killEmulatorProcess();
-                });
+        if (self.config.getAction() !== 'build') {
+            if (!self.config.shouldUseSauce()) {
+                // collect logs and uninstall app
+                self.collectDeviceLogs();
+                return self.uninstallApp()
+                    .fail(function () {
+                        // do not fail if uninstall fails
+                    })
+                    .fin(function () {
+                        self.killEmulatorProcess();
+                    });
+            } else {
+                return self.paramedicSauceLabs.displaySauceDetails(self.sauceBuildName);
+            }
         }
-        return self.paramedicSauceLabs.displaySauceDetails(self.sauceBuildName);
     })
     .fin(function () {
         self.cleanUpProject();


### PR DESCRIPTION
### Platforms affected
All

### Motivation and Context
Fixes the bug #111 that was preventing a `justbuild` execution of cordova-paramedic 

### Description
I moved the `self.paramedicSauceLabs.displaySauceDetails(self.sauceBuildName)` call to be excuted only when action is `build`

### Testing
After installed the module locally with the fix,  I executed  :

```
cordova-paramedic --platform ios --plugin cordova-plugin-inappbrowser --justbuild
```



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
