### PR TITLE
Make Travis CI more copy-able to plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,23 +74,28 @@ matrix:
       <<: *_android
 
 before_install:
-  - if [[ "$PLATFORM" =~ android ]]; then nvm install $TRAVIS_NODE_VERSION; fi # manually install Node for `language: android`
+  - if [ "$PLATFORM" =~ android ]; then nvm install $TRAVIS_NODE_VERSION; fi # manually install Node for `language: android`
   - node --version
-  - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
-  - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
+  - if [ "$PLATFORM" =~ android ]; then gradle --version; fi
+  - if [ "$PLATFORM" =~ ios ]; then npm install -g ios-deploy; fi
   - npm install -g cordova
-  - if [[ "$TRAVIS_REPO_SLUG" !=~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic; fi # install paramedic if not running on paramedic
+  - if [ "$TRAVIS_REPO_SLUG" !=~ cordova-paramedic ]; then npm install -g github:apache/cordova-paramedic; fi # install paramedic if not running on paramedic
 install:
   - npm install
 
 before_script:
+  - |
+    if [ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]; then # when used in the cordova-paramedic repo
+      TEST_COMMAND=npm run eslint
+      PARAMEDIC_PLUGIN_TO_TEST=./spec/testable-plugin/
+      PARAMEDIC_COMMAND=node main.js
+    else # when used in any other (plugin) repo
+      TEST_COMMAND=npm test
+      PARAMEDIC_PLUGIN_TO_TEST=$(pwd)
+      PARAMEDIC_COMMAND=cordova-paramedic
+    fi
   - PARAMEDIC_BUILDNAME=travis-$TRAVIS_REPO_SLUG-$TRAVIS_JOB_NUMBER
-  - if [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then PARAMEDIC_PLUGIN_TO_TEST=./spec/testable-plugin/; fi
-  - if [[ "$TRAVIS_REPO_SLUG" !=~ cordova-paramedic ]]; then PARAMEDIC_PLUGIN_TO_TEST=$(pwd); fi
-   - if [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then PARAMEDIC_COMMAND=node main.js; fi
-  - if [[ "$TRAVIS_REPO_SLUG" !=~ cordova-paramedic ]]; then PARAMEDIC_COMMAND=cordova-paramedic; fi
-
-
+  
 script:
-  - npm run eslint
+  - $TEST_COMMAND
   - $PARAMEDIC_COMMAND --config ./pr/$PLATFORM --plugin $PARAMEDIC_PLUGIN_TO_TEST --buildName $PARAMEDIC_BUILDNAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,25 +74,27 @@ matrix:
       <<: *_android
 
 before_install:
-  - if [ "$PLATFORM" =~ android ]; then nvm install $TRAVIS_NODE_VERSION; fi # manually install Node for `language: android`
+  - if [[ "$PLATFORM" =~ android ]]; then nvm install $TRAVIS_NODE_VERSION; fi # manually install Node for `language: android`
   - node --version
-  - if [ "$PLATFORM" =~ android ]; then gradle --version; fi
-  - if [ "$PLATFORM" =~ ios ]; then npm install -g ios-deploy; fi
+  - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
+  - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
   - npm install -g cordova
-  - if [ "$TRAVIS_REPO_SLUG" !=~ cordova-paramedic ]; then npm install -g github:apache/cordova-paramedic; fi # install paramedic if not running on paramedic
+  - if [[ "$TRAVIS_REPO_SLUG" !=~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic; fi # install paramedic if not running on paramedic
 install:
   - npm install
 
 before_script:
   - |
-    if [ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]; then # when used in the cordova-paramedic repo
-      TEST_COMMAND=npm run eslint
-      PARAMEDIC_PLUGIN_TO_TEST=./spec/testable-plugin/
-      PARAMEDIC_COMMAND=node main.js
-    else # when used in any other (plugin) repo
-      TEST_COMMAND=npm test
+    if [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then 
+      # when used in the cordova-paramedic repo
+      TEST_COMMAND="npm run eslint"
+      PARAMEDIC_PLUGIN_TO_TEST=""./spec/testable-plugin/""
+      PARAMEDIC_COMMAND="node main.js"
+    else 
+      # when used in any other (plugin) repo
+      TEST_COMMAND="npm test"
       PARAMEDIC_PLUGIN_TO_TEST=$(pwd)
-      PARAMEDIC_COMMAND=cordova-paramedic
+      PARAMEDIC_COMMAND="cordova-paramedic"
     fi
   - PARAMEDIC_BUILDNAME=travis-$TRAVIS_REPO_SLUG-$TRAVIS_JOB_NUMBER
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ addons:
   # sauce labs key
   jwt:
     secure: NJr2X/VRsRjy/6cQqrx1kVwNH8UmVq4Ns90UjHMYFeSjacczc42qOCgMfCOxN8FBa5T6H7vqGnloTdpp56Vm1BPSLqX/M3uT1gM9/yGDsgKzEC90tt2WrGSyp7C2LRs5+EF+bj5hvFd+iO4bLA7nTnOTzgxwwzzsau0ljxx1VHbVHi2xOwuK7/ShwOhxfkNEHeJ76X/1sjssKgU++tU3uUAdiBqUupqpQmWVPsxKTp4svOcNNlBKqk+SMX8EDmeU36AXC3QBMVWmpug0z55gmmGsu8bAWRo6iKc9U0B43g5Tgw3DaRs/cNNJWN3mX/04hVJFJEzHvGaTbEvOXngHyDAtuDl9FiHYZpJK3H5eRhcXAh6IQXloYnXTzEQCIaX3N9p8gpFmMgOhMPy5a0iSIv2wcU1bNtzfbD5JokJp0vLsFphSrvhlOfKwOg0pq/dU66P1MTwHj6bwmxPK+GtQu8hRY/pA/yd9sTyuwp8CUyKkLWTSoQCqQ9xXbyJmxU3B8obiDRA/321LD8m4jlJy9zJO+pt/wt7zCh081G3bFsyO8VYLkhIQzXYQpppVLHArwImGip82T52c7OUtqknlchLdjoYHVd5zT8k3gqY5mVE6bIS4OFkXAFrQnBUafvAILUfSE7vcrCeNh8UzfGIdq3wFad1zc2NnCx/L/PUgpVM=
+
 env:
   global:
     - SAUCE_USERNAME=snay
@@ -12,8 +13,7 @@ env:
     - ANDROID_BUILD_TOOLS_VERSION=28.0.3
 
 language: node_js
-node_js: 
-  - "6"
+node_js: 6
 
 # yaml anchor/alias: https://medium.com/@tommyvn/travis-yml-dry-with-anchors-8b6a3ac1b027
 
@@ -79,12 +79,18 @@ before_install:
   - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
   - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
   - npm install -g cordova
+  - if [[ "$TRAVIS_REPO_SLUG" !=~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic; fi # install paramedic if not running on paramedic
 install:
   - npm install
 
 before_script:
-  - PARAMEDIC_BUILDNAME=travis-plugin-splashscreen-$TRAVIS_JOB_NUMBER
-  
+  - PARAMEDIC_BUILDNAME=travis-$TRAVIS_REPO_SLUG-$TRAVIS_JOB_NUMBER
+  - if [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then PARAMEDIC_PLUGIN_TO_TEST=./spec/testable-plugin/; fi
+  - if [[ "$TRAVIS_REPO_SLUG" !=~ cordova-paramedic ]]; then PARAMEDIC_PLUGIN_TO_TEST=$(pwd); fi
+   - if [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then PARAMEDIC_COMMAND=node main.js; fi
+  - if [[ "$TRAVIS_REPO_SLUG" !=~ cordova-paramedic ]]; then PARAMEDIC_COMMAND=cordova-paramedic; fi
+
+
 script:
   - npm run eslint
-  - node main.js --config ./pr/$PLATFORM --plugin ./spec/testable-plugin/ --buildName $PARAMEDIC_BUILDNAME
+  - $PARAMEDIC_COMMAND --config ./pr/$PLATFORM --plugin $PARAMEDIC_PLUGIN_TO_TEST --buildName $PARAMEDIC_BUILDNAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,5 +82,9 @@ before_install:
 install:
   - npm install
 
+before_script:
+  - PARAMEDIC_BUILDNAME=travis-plugin-splashscreen-$TRAVIS_JOB_NUMBER
+  
 script:
-  - node main.js --config ./pr/$PLATFORM --plugin ./spec/testable-plugin/ --buildName travis-paramedic-$TRAVIS_JOB_NUMBER;
+  - npm run eslint
+  - node main.js --config ./pr/$PLATFORM --plugin ./spec/testable-plugin/ --buildName $PARAMEDIC_BUILDNAME

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,8 @@ before_install:
   - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
   - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
   - npm install -g cordova
-  - if [[ "$TRAVIS_REPO_SLUG" !=~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic; fi # install paramedic if not running on paramedic
+  - if ! [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic; fi # install paramedic if not running on paramedic
+
 install:
   - npm install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,12 +74,14 @@ matrix:
       <<: *_android
 
 before_install:
-  - if [[ "$PLATFORM" =~ android ]]; then nvm install $TRAVIS_NODE_VERSION; fi # manually install Node for `language: android`
+  # manually install Node for `language: android`
+  - if [[ "$PLATFORM" =~ android ]]; then nvm install $TRAVIS_NODE_VERSION; fi 
   - node --version
   - if [[ "$PLATFORM" =~ android ]]; then gradle --version; fi
   - if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
   - npm install -g cordova
-  - if ! [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic; fi # install paramedic if not running on paramedic
+  # install paramedic if not running on paramedic repo
+  - if ! [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then npm install -g github:apache/cordova-paramedic; fi 
 
 install:
   - npm install


### PR DESCRIPTION
This rewrite the travis CI config in a way so that it can almost just be copied over to the plugin repos (besides the Sauce Key in `addons.jwt.secure`). This should make updating the config in the plugins much easier and more efficient.

- Extract `PARAMEDIC_BUILDNAME` to `before_script` to make it more obvious this is a variable
- run `npm run eslint` (and fix file that was not passing that check)
- run `npm install -g github:apache/cordova-paramedic` if not running in paramedic repo
- Create `TEST_COMMAND`, `PARAMEDIC_PLUGIN_TO_TEST` and `PARAMEDIC_COMMAND` that are filled depending on what repo the config is run for (paramedic vs. plugin)
- simplify syntax

---

@alsorokin This changes the format of the buildname on Saucelabs from `travis-plugin-splashscreen-383.8` to `travis-apache/cordova-plugin-splashscreen-383.8`. Any reason why this might be bad idea?