### PR TITLE
Remove unsupported SauceLabs iOS simulators (iOS 9.3 and 10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,6 @@ matrix:
     - env: PLATFORM=browser-safari
     - env: PLATFORM=browser-edge
 
-    - env: PLATFORM=ios-10.0
-      <<: *_ios
     - env: PLATFORM=ios-11.3
       <<: *_ios
     - env: PLATFORM=ios-12.0

--- a/conf/pr/ios-10.0.config.json
+++ b/conf/pr/ios-10.0.config.json
@@ -1,9 +1,0 @@
-{
-    "platform": "ios",
-    "action": "run",
-    "cleanUpAfterRun": true,
-    "shouldUseSauce": true,
-    "saucePlatformVersion": "10.0",
-    "sauceAppiumVersion": "1.6.4",
-    "verbose": true
-}

--- a/conf/pr/ios-9.3.config.json
+++ b/conf/pr/ios-9.3.config.json
@@ -1,8 +1,0 @@
-{
-    "platform": "ios@4.5.5",
-    "args": "--buildFlag='-UseModernBuildSystem=0'",
-    "action": "run",
-    "cleanUpAfterRun": true,
-    "verbose": true,
-    "saucePlatformVersion": "9.3"
-}


### PR DESCRIPTION
https://wiki.saucelabs.com/display/DOCS/2019/03/07/Announcing+End+of+Life+for+old+OS+versions+on+Sauce+emulators+and+simulators