### PR TITLE
ADDITIONAL_TESTS_DIR (to replace TEST_DIR)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ _android: &_android
 matrix:
   include:
     # additional tests via package.json
-    - env: ADDITIONAL_TESTS=./spec/testable-plugin/foo
+    - env: ADDITIONAL_TESTS=./spec/testable-plugin/tests/foo
       <<: *_ios
     
     # local tests, without saucelabs

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ _android: &_android
 
 matrix:
   include:
-    # additional tests via package.json
-    - env: ADDITIONAL_TESTS=./spec/testable-plugin/tests/foo
+    # additional `npm test` in directory
+    - env: ADDITIONAL_TESTS_DIR=./spec/testable-plugin/tests/foo
       <<: *_ios
     
     # local tests, without saucelabs
@@ -105,8 +105,8 @@ before_script:
   
 script:
   - $TEST_COMMAND
-  - if [[ "$ADDITIONAL_TESTS" != "" ]]; 
-      then cd $ADDITIONAL_TESTS && npm install && npm test;
+  - if [[ "$ADDITIONAL_TESTS_DIR" != "" ]]; 
+      then cd $ADDITIONAL_TESTS_DIR && npm install && npm test;
     else 
       $PARAMEDIC_COMMAND --config ./pr/$PLATFORM --plugin $PARAMEDIC_PLUGIN_TO_TEST --buildName $PARAMEDIC_BUILDNAME; 
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,11 @@ _android: &_android
 
 matrix:
   include:
-    # one local test, without saucelabs
+    # additional tests via package.json
+    - env: ADDITIONAL_TESTS=./spec/testable-plugin/foo
+      <<: *_ios
+    
+    # local tests, without saucelabs
     - env: PLATFORM=local/browser
       <<: *_ios
     - env: PLATFORM=local/ios-10.0
@@ -89,7 +93,7 @@ before_script:
     if [[ "$TRAVIS_REPO_SLUG" =~ cordova-paramedic ]]; then 
       # when used in the cordova-paramedic repo
       TEST_COMMAND="npm run eslint"
-      PARAMEDIC_PLUGIN_TO_TEST=""./spec/testable-plugin/""
+      PARAMEDIC_PLUGIN_TO_TEST="./spec/testable-plugin/"
       PARAMEDIC_COMMAND="node main.js"
     else 
       # when used in any other (plugin) repo
@@ -101,4 +105,8 @@ before_script:
   
 script:
   - $TEST_COMMAND
-  - $PARAMEDIC_COMMAND --config ./pr/$PLATFORM --plugin $PARAMEDIC_PLUGIN_TO_TEST --buildName $PARAMEDIC_BUILDNAME
+  - if [[ "$ADDITIONAL_TESTS" != "" ]]; 
+      then cd $ADDITIONAL_TESTS && npm install && npm test;
+    else 
+      $PARAMEDIC_COMMAND --config ./pr/$PLATFORM --plugin $PARAMEDIC_PLUGIN_TO_TEST --buildName $PARAMEDIC_BUILDNAME; 
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,8 +105,8 @@ before_script:
   
 script:
   - $TEST_COMMAND
-  - if [[ "$ADDITIONAL_TESTS_DIR" != "" ]]; 
-      then cd $ADDITIONAL_TESTS_DIR && npm install && npm test;
+  - if [[ "$ADDITIONAL_TESTS_DIR" != "" ]]; then
+      cd $ADDITIONAL_TESTS_DIR && npm install && npm test;
     else 
       $PARAMEDIC_COMMAND --config ./pr/$PLATFORM --plugin $PARAMEDIC_PLUGIN_TO_TEST --buildName $PARAMEDIC_BUILDNAME; 
     fi

--- a/spec/testable-plugin/tests/foo/package.json
+++ b/spec/testable-plugin/tests/foo/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "cordova-plugin-testable-test-foo",
+  "name": "testable-plugin-tests-foo",
   "version": "1.0.0",
-  "description": "Additional Tests for Testable Plugin",
-  "author": "",
-  "license": "",
+  "description": "Additional tests for testable plugin",
   "scripts": {
     "test": "echo \"Here could be additional tests.\""
   },
+  "author": ""
+  "license": ""
 }

--- a/spec/testable-plugin/tests/foo/package.json
+++ b/spec/testable-plugin/tests/foo/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "testable-plugin-tests-foo",
-  "version": "1.0.0",
-  "description": "Additional tests for testable plugin",
-  "scripts": {
-    "test": "echo \"Here could be additional tests.\""
-  },
-  "author": ""
-  "license": ""
+	"name": "testable-plugin-tests-foo",
+	"version": "1.0.0",
+	"description": "Additional tests for testable plugin",
+	"scripts": {
+		"test": "echo \"Here could be additional tests.\""
+	},
+	"author": "",
+	"license": ""
 }

--- a/spec/testable-plugin/tests/foo/package.json
+++ b/spec/testable-plugin/tests/foo/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cordova-plugin-testable-test-foo",
+  "version": "1.0.0",
+  "description": "Additional Tests for Testable Plugin",
+  "author": "",
+  "license": "",
+  "scripts": {
+    "test": "echo \"Here could be additional tests.\""
+  },
+}


### PR DESCRIPTION
Before, some plugins had something like this:

```
  - env: TEST_DIR=.
    language: objective-c
  - env: TEST_DIR=./tests/ios
    language: objective-c
```

which was run via

```
  - if [[ "$TEST_DIR" != "" ]]; then
      cd $TEST_DIR;
      npm install;
      npm test;
    else
      cordova-paramedic --config pr/$PLATFORM --plugin . --shouldUseSauce --buildName travis-plugin-camera-$TRAVIS_JOB_NUMBER;
   fi
```

the `if [[ "$TEST_DIR" != "" ]]; then` was not part of the paramedic config, so got overlooked when cleaning up the travis.yml that then got copied over to plugins. When adding the `env` back to the plugin travis.yml config, it failed (see #141).

---

As this is an important feature for 2 plugins, it has to be reinstated:

- `TEST_DIR=.` only ran the local `npm test`, this is now part of travis.yml anyway.
- `TEST_DIR=./tests/ios` still has value, so has to find a new place.

---

This PR ads `ADDITIONAL_TESTS` and recreates the `if/else` that was there before. It also adds a pseudo test to `/spec/testable-plugin/tests/foo` so that this can be tested on paramedic itself as well.

closes #141