### PR TITLE
feat: Appium "Test"

### DIFF
--- a/lib/appium/AppiumRunner.js
+++ b/lib/appium/AppiumRunner.js
@@ -221,6 +221,7 @@ class AppiumRunner {
             searchPaths.push(path.join(pluginRepo, 'appium-tests', 'common'));
         });
         searchPaths.forEach((searchPath) => {
+            logger.normal('paramedic-appium: Looking for tests in: ' + searchPath);
             if (fs.existsSync(searchPath)) {
                 logger.normal('paramedic-appium: Found tests in: ' + searchPath);
                 if (path.isAbsolute(searchPath)) {

--- a/lib/appium/helpers/wdHelper.js
+++ b/lib/appium/helpers/wdHelper.js
@@ -78,7 +78,8 @@ module.exports.getDriver = function (platform) {
             platformVersion: global.PLATFORM_VERSION || '',
             deviceName: global.DEVICE_NAME || '',
             app: global.PACKAGE_PATH,
-            autoAcceptAlerts: true
+            autoAcceptAlerts: true,
+            automationName: 'XCUITest'
         };
 
         if (global.UDID) {

--- a/spec/testable-plugin/appium-tests/common/common.spec.js
+++ b/spec/testable-plugin/appium-tests/common/common.spec.js
@@ -72,6 +72,17 @@ describe('Testable Plugin UI Automation Tests', function () {
                 var promiseId = getNextPromiseId();
                 return driver
                     .context(webviewContext)
+                    .execute(function (pID) {
+                        navigator._appiumPromises[pID] = Q.defer();
+                        return Q.fcall(function () {
+                            return 'success';
+                        })
+                        .then(function (result) {
+                            navigator._appiumPromises[pID].resolve(result);
+                        }, function (err) {
+                            navigator._appiumPromises[pID].reject(err);
+                        });
+                    }, [promiseId])
                     .executeAsync(function (pID, cb) {
                         navigator._appiumPromises[pID].promise
                             .then(function (result) {

--- a/spec/testable-plugin/appium-tests/common/common.spec.js
+++ b/spec/testable-plugin/appium-tests/common/common.spec.js
@@ -1,0 +1,92 @@
+'use strict';
+
+var wdHelper = global.WD_HELPER;
+var screenshotHelper = global.SCREENSHOT_HELPER;
+
+var MINUTE = 60 * 1000;
+
+describe('Testable Plugin UI Automation Tests', function () {
+    var driver;
+    var webviewContext;
+    var promiseCount = 0;
+    // going to set this to false if session is created successfully
+    var failedToStart = true;
+
+    function getNextPromiseId() {
+        return 'appium_promise_' + promiseCount++;
+    }
+
+    function saveScreenshotAndFail(error) {
+        fail(error);
+        return screenshotHelper
+            .saveScreenshot(driver)
+            .quit()
+            .then(function () {
+                return getDriver();
+            });
+    }
+
+    function getDriver() {
+        driver = wdHelper.getDriver(PLATFORM);
+        return wdHelper.getWebviewContext(driver, 2)
+            .then(function (context) {
+                webviewContext = context;
+                return driver.context(webviewContext);
+            })
+            .then(function () {
+                return wdHelper.waitForDeviceReady(driver);
+            })
+            .then(function () {
+                return wdHelper.injectLibraries(driver);
+            });
+    }
+    
+        function checkSession(done) {
+        if (failedToStart) {
+            fail('Failed to start a session');
+            done();
+        }
+    }
+
+    afterAll(function (done) {
+        checkSession(done);
+        driver
+            .quit()
+            .done(done);
+    }, MINUTE);
+
+    it('should connect to an appium endpoint properly', function (done) {
+        // retry up to 3 times
+        getDriver()
+            .fail(function () {
+                return getDriver()
+                    .fail(function () {
+                        return getDriver()
+                            .fail(fail);
+                    });
+            })
+            .then(function () {
+                failedToStart = false;
+            }, fail)
+            .then(function () {
+                var promiseId = getNextPromiseId();
+                return driver
+                    .context(webviewContext)
+                    .executeAsync(function (pID, cb) {
+                        navigator._appiumPromises[pID].promise
+                            .then(function (result) {
+                                cb(result);
+                            }, function (err) {
+                                cb('ERROR: ' + err);
+                            });
+                    }, [promiseId])
+                    .then(function (result) {
+                        if (typeof result === 'string' && result.indexOf('ERROR:') === 0) {
+                            throw result;
+                        }
+                        return result;
+                    });
+            })
+            .done(done);
+    }, 30 * MINUTE);
+});

--- a/spec/testable-plugin/plugin.xml
+++ b/spec/testable-plugin/plugin.xml
@@ -21,7 +21,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="org.apache.cordova.testable-plugin"
+    id="testable-plugin"
     version="0.0.1">
     <name>Testable Plugin</name>
     <description>Cordova Testing Plugin</description>


### PR DESCRIPTION
This adds Appium tests to the `testable-plugin` which is used to test Paramedic functionality.

The spec file is extracted from https://github.com/apache/cordova-plugin-contacts/blob/master/appium-tests/common/common.spec.js and probably pretty bad.

CI is of course failing because of https://github.com/apache/cordova-paramedic/issues/142