### PR TITLE
execute launching app and waiting results in parallel

### DIFF
--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -240,7 +240,7 @@ class ParamedicRunner {
                         }
 
                         // skip tests if it was just build
-                        if (self.shouldWaitForTestResult()) {
+                        if (this.shouldWaitForTestResult()) {
                             return Q.promise((resolve, reject) => {
                             // reject if timed out
                                 self.waitForConnection().catch(reject);

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -221,7 +221,7 @@ class ParamedicRunner {
                     Q().then(() => {
                         logger.normal('cordova-paramedic: running command ' + command);
 
-                        if (self.config.getPlatformId() !== utilities.BROWSER) {
+                        if (this.config.getPlatformId() !== utilities.BROWSER) {
                             return execPromise(command);
                         }
                         console.log('$ ' + command);

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -234,7 +234,7 @@ class ParamedicRunner {
                     Q().then(() => {
                         // skipping here and not at the beginning because we need to
                         // start up the Android emulator for Appium tests to run on
-                        if (!self.config.runMainTests()) {
+                        if (!this.config.runMainTests()) {
                             logger.normal('Skipping main tests...');
                             return utilities.TEST_PASSED;
                         }

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -231,7 +231,7 @@ class ParamedicRunner {
                             runProcess = null;
                         });
                     }),
-                    Q().then(function () {
+                    Q().then(() => {
                         // skipping here and not at the beginning because we need to
                         // start up the Android emulator for Appium tests to run on
                         if (!self.config.runMainTests()) {

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -218,7 +218,7 @@ class ParamedicRunner {
                 this.setPermissions();
 
                 return Q.all([
-                    Q().then(function () {
+                    Q().then(() => {
                         logger.normal('cordova-paramedic: running command ' + command);
 
                         if (self.config.getPlatformId() !== utilities.BROWSER) {

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -216,37 +216,47 @@ class ParamedicRunner {
             .then(() => this.getCommandForStartingTests())
             .then((command) => {
                 this.setPermissions();
-                logger.normal('cordova-paramedic: running command ' + command);
+                const self = this;
 
-                if (this.config.getPlatformId() !== utilities.BROWSER) {
-                    return execPromise(command);
-                }
-                console.log('$ ' + command);
+                return Q.all([
+                    Q().then(function () {
+                        logger.normal('cordova-paramedic: running command ' + command);
 
-                // a precaution not to try to kill some other process
-                runProcess = cp.exec(command, () => {
-                    runProcess = null;
-                });
+                        if (self.config.getPlatformId() !== utilities.BROWSER) {
+                            return execPromise(command);
+                        }
+                        console.log('$ ' + command);
+
+                        // a precaution not to try to kill some other process
+                        runProcess = cp.exec(command, () => {
+                            runProcess = null;
+                        });
+                    }),
+                    Q().then(function () {
+                        // skipping here and not at the beginning because we need to
+                        // start up the Android emulator for Appium tests to run on
+                        if (!self.config.runMainTests()) {
+                            logger.normal('Skipping main tests...');
+                            return utilities.TEST_PASSED;
+                        }
+
+                        // skip tests if it was just build
+                        if (self.shouldWaitForTestResult()) {
+                            return Q.promise((resolve, reject) => {
+                            // reject if timed out
+                                self.waitForConnection().catch(reject);
+                                // resolve if got results
+                                self.waitForTests().then(resolve);
+                            });
+                        }
+
+                        return utilities.TEST_PASSED; // if we're not waiting for a test result, just report tests as passed
+                    })
+                ]);
+
             })
-            .then(() => {
-            // skipping here and not at the beginning because we need to
-            // start up the Android emulator for Appium tests to run on
-                if (!this.config.runMainTests()) {
-                    logger.normal('Skipping main tests...');
-                    return utilities.TEST_PASSED;
-                }
-
-                // skip tests if it was just build
-                if (this.shouldWaitForTestResult()) {
-                    return Q.promise((resolve, reject) => {
-                    // reject if timed out
-                        this.waitForConnection().catch(reject);
-                        // resolve if got results
-                        this.waitForTests().then(resolve);
-                    });
-                }
-
-                return utilities.TEST_PASSED; // if we're not waiting for a test result, just report tests as passed
+            .then((results) => {
+                return results[1];
             })
             .fin((result) => {
                 return runProcess

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -243,7 +243,7 @@ class ParamedicRunner {
                         if (this.shouldWaitForTestResult()) {
                             return Q.promise((resolve, reject) => {
                             // reject if timed out
-                                self.waitForConnection().catch(reject);
+                                this.waitForConnection().catch(reject);
                                 // resolve if got results
                                 self.waitForTests().then(resolve);
                             });

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -216,7 +216,6 @@ class ParamedicRunner {
             .then(() => this.getCommandForStartingTests())
             .then((command) => {
                 this.setPermissions();
-                const self = this;
 
                 return Q.all([
                     Q().then(function () {

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -245,7 +245,7 @@ class ParamedicRunner {
                             // reject if timed out
                                 this.waitForConnection().catch(reject);
                                 // resolve if got results
-                                self.waitForTests().then(resolve);
+                                this.waitForTests().then(resolve);
                             });
                         }
 


### PR DESCRIPTION
This PR is basically same as the previous PR:  https://github.com/apache/cordova-paramedic/pull/51#issuecomment-487122818

This PR is based on the current master branch.

### Platforms affected
All platforms (tests only)
Main target is Windows 10.

### Motivation and Context
Fix #38 .

Without this PR, in runLocalTests following tasks are called in order.

 1.   launching test application
 2.  waiting application test results

However sometimes jasmine's tests in application are finished before the corodva-paramedic starts to wait the test results. I met this issue in Windows 10. (Please see #38)


### Description

With this PR, the above two tasks are called in parallel.
Then the cordova-paramedic can detect jasmine tests' results normally.


### Testing
In my local PC (Windows 10),

```
npm run test-windows
```

(with Windows Loopback Exemption Manager as mentioned https://github.com/apache/cordova-paramedic#windows-quirks )

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary