### PR TITLE
CI, Saucelabs: Android 9 Emulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,8 @@ matrix:
       <<: *_android
     - env: PLATFORM=android-8.1
       <<: *_android
+    - env: PLATFORM=android-9.0
+      <<: *_android
 
 before_install:
   # manually install Node for `language: android`

--- a/conf/pr/android-9.0.config.json
+++ b/conf/pr/android-9.0.config.json
@@ -1,0 +1,9 @@
+{
+    "platform": "android",
+    "action": "run",
+    "cleanUpAfterRun": true,
+    "shouldUseSauce": true,
+    "saucePlatformVersion": "9.0",
+    "sauceDeviceName": "Android GoogleAPI Emulator",
+    "verbose": true
+}


### PR DESCRIPTION
https://wiki.saucelabs.com/display/DOCS/2019/05/30/Android+9.0%2C+now+available+on+Sauce+Labs+emulators