### PR TITLE
fix: run local ios 10 tests on actual iOS 10 device

### DIFF
--- a/conf/pr/local/ios-10.0.config.json
+++ b/conf/pr/local/ios-10.0.config.json
@@ -2,6 +2,6 @@
     "platform": "ios",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "iPhone-XR, 10.0",
+    "target": "iPhone-SE, 10.0",
     "verbose": true
 }

--- a/conf/pr/local/ios-10.0.config.json
+++ b/conf/pr/local/ios-10.0.config.json
@@ -2,6 +2,6 @@
     "platform": "ios",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "iPhone-XR",
+    "target": "iPhone-XR, 10.0",
     "verbose": true
 }

--- a/conf/pr/local/ios-10.0.config.json
+++ b/conf/pr/local/ios-10.0.config.json
@@ -2,6 +2,6 @@
     "platform": "ios",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "iPhone-SE, 10.0",
+    "target": "iPhone-6s-Plus, 10.0",
     "verbose": true
 }


### PR DESCRIPTION
During an earlier PR the iOS version got removed. This of course doesn't make too much sense if you want to be able to test on specific iOS versions.