### PR TITLE
Clean up parameter handling and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A full Paramedic run will:
         1. Skip if no Appium tests were found <!-- 7-427 -->  
         1. Prepare App in AppiumRunner <!-- 7-433 -->
             1. Remove server address from app
-            2. Reconfigure app (modify preferences + CSP, add plugin) <!-- 367, 375, 385 -- >
+            2. Reconfigure app (modify preferences + CSP, add plugin) <!-- 367, 375, 385 -->
             3. Build app
         1. (sauce) Package and Upload the App to Sauce Labs <!-- 7-436 -->
         1. Run tests via AppiumRunner <!-- 7-442 -->
@@ -175,7 +175,7 @@ cordova-paramedic --config conf/pr/android-7.0 --plugin ./
 
 ## Command Line Interface
 
-### What to build and test
+### What and how to build and test
 
 #### `--platform` (required)
 
@@ -217,12 +217,32 @@ A path to Cordova CLI. Useful when you're testing against locally installed Cord
 cordova-paramedic --platform android --plugin cordova-plugin-device --cli ./cordova-cli/bin/cordova
 ```
 
+#### `--action` (optional)
+
+TODO
+
 #### `--justbuild` (optional)
 
 Just builds the project, without running the tests.
 
 ```
 cordova-paramedic --platform ios --plugin cordova-plugin-inappbrowser --justbuild
+```
+
+#### `--skipMainTests` (optional)
+
+TODO
+
+#### `--skipAppiumTests` (optional)
+
+TODO
+
+#### `--args` (optional)
+
+Add additional parameters to the `cordova build` and `cordova run` commands.
+
+```
+cordova-paramedic --platform ios --plugin cordova-plugin-contacts --args=--buildFlag='-UseModernBuildSystem=0'
 ```
 
 ### Emulator/Device to use for tests
@@ -312,14 +332,6 @@ iOS only parameter. The path to the sample TCC DB file, with permissions, to be 
 cordova-paramedic --platform ios --plugin cordova-plugin-contacts --tccDbPath tcc.db
 ```
 
-#### `--args` (optional)
-
-Add additional parameters to the `cordova build` and `cordova run` commands.
-
-```
-cordova-paramedic --platform ios --plugin cordova-plugin-contacts --args=--buildFlag='-UseModernBuildSystem=0'
-```
-
 ### Sauce Labs
 
 #### `--shouldUseSauce` (optional)
@@ -357,6 +369,26 @@ Appium version to use when running on Sauce Labs. For example, "1.5.3".
 ```
 cordova-paramedic --platform ios --plugin cordova-plugin-contacts --shouldUseSauce --sauceUser ***** --sauceKey ***** --sauceDeviceName 'iPad Simulator" --saucePlatformVersion 9.1 --appiumVersion 1.5.2
 ```
+
+#### `--sauceTunnelId`(optional)
+
+Tunnel identifier to use. Only usable if you have Sauce Connect up
+
+TODO
+
+### Others
+
+#### `--ci` (optional)
+
+Skip tests that require user interaction
+
+TODO
+
+#### `--fileTransferServer` (optional)
+
+(cordova-plugin-file-transfer only) A server address tests should connect to
+
+TODO
 
 ## Configuration file
 

--- a/lib/ParamedicConfig.js
+++ b/lib/ParamedicConfig.js
@@ -279,33 +279,46 @@ class ParamedicConfig {
 
 ParamedicConfig.parseFromArguments = function (argv) {
     return new ParamedicConfig({
+        // What and how to build and test
         platform: argv.platform,
-        action: argv.justbuild || argv.justBuild ? 'build' : 'run',
-        args: '',
         plugins: Array.isArray(argv.plugin) ? argv.plugin : [argv.plugin],
-        useTunnel: !!argv.useTunnel,
         verbose: !!argv.verbose,
+        cli: argv.cli,
+        action: argv.justbuild || argv.justBuild ? 'build' : 'run', // TODO argv.action
+        skipMainTests: argv.skipMainTests,
+        skipAppiumTests: argv.skipAppium,
+        args: '',
+
+        // Emulator/Device to use for tests
+        target: argv.target,
+
+        // Test Result Server
+        useTunnel: !!argv.useTunnel,
+        externalServerUrl: argv.externalServerUrl,
         startPort: argv.startport || argv.port,
         endPort: argv.endport || argv.port,
-        externalServerUrl: argv.externalServerUrl,
+
+        // Test configuration
+        // timeout?
         outputDir: argv.outputDir ? argv.outputDir : null,
+        cleanUpAfterRun: !!argv.cleanUpAfterRun,
         logMins: argv.logMins ? argv.logMins : null,
         tccDb: argv.tccDbPath ? argv.tccDb : null,
-        cleanUpAfterRun: !!argv.cleanUpAfterRun,
+
+        // Sauce Labs
         shouldUseSauce: !!argv.shouldUseSauce || false,
-        buildName: argv.buildName,
         sauceUser: argv.sauceUser,
         sauceKey: argv.sauceKey,
+        buildName: argv.buildName,
         sauceDeviceName: argv.sauceDeviceName && argv.sauceDeviceName.toString(),
         saucePlatformVersion: argv.saucePlatformVersion && argv.saucePlatformVersion.toString(),
         sauceAppiumVersion: argv.sauceAppiumVersion && argv.sauceAppiumVersion.toString(),
         sauceTunnelId: argv.sauceTunnelId,
-        skipAppiumTests: argv.skipAppium,
-        skipMainTests: argv.skipMainTests,
+
+        // Others
         ci: argv.ci,
-        target: argv.target,
-        fileTransferServer: argv.fileTransferServer,
-        cli: argv.cli
+        fileTransferServer: argv.fileTransferServer
+
     });
 };
 

--- a/main.js
+++ b/main.js
@@ -19,57 +19,61 @@
  * under the License.
  */
 
-var parseArgs       = require('minimist');
-var path            = require('path');
-var paramedic       = require('./lib/paramedic');
+var parseArgs = require('minimist');
+var paramedic = require('./lib/paramedic');
 var ParamedicConfig = require('./lib/ParamedicConfig');
-var util            = require('./lib/utils').utilities;
+var util = require('./lib/utils').utilities;
 
-var USAGE           = "Error missing args. \n" +
-    "\n" +
-    "cordova-paramedic --platform PLATFORM --plugin PATH [--justbuild --timeout MSECS --startport PORTNUM --endport PORTNUM --version ...]\n" +
-    "\n" +
+var USAGE = 'Error missing args. \n' +
+    '\n' +
+    'cordova-paramedic --platform PLATFORM --plugin PATH [--justbuild --timeout MSECS --startport PORTNUM --endport PORTNUM --version ...]\n' +
+    '\n' +
+    'required parameters (unless --config was used):\n' +
     "--platform PLATFORM : the platform id. Currently supports 'ios', 'browser', 'windows', 'android'.\n" +
-                    "\tPath to platform can be specified as link to git repo like:\n" +
-                    "\twindows@https://github.com/apache/cordova-windows.git\n" +
-                    "\tor path to local copied git repo like:\n" +
-                    "\twindows@../cordova-windows/\n" +
-    "--plugin PATH : the relative or absolute path to a plugin folder\n" +
+                    '\tPath to platform can be specified as link to git repo like:\n' +
+                    '\twindows@https://github.com/apache/cordova-windows.git\n' +
+                    '\tor path to local copied git repo like:\n' +
+                    '\twindows@../cordova-windows/\n' +
+    '--plugin PATH : the relative or absolute path to a plugin folder\n' +
                     "\texpected to have a 'tests' folder.\n" +
-                    "\tYou may specify multiple --plugin flags and they will all\n" +
-                    "\tbe installed and tested together.\n" +
-    "\n" +
-    "--args: (optional) add command line args to the \"cordova build\" and \"cordov run\" commands \n" +
-    "--buildName : (optional) Build name to show in Saucelabs dashboard\n" +
-    "--ci : (optional) Skip tests that require user interaction\n" +
-    "--cleanUpAfterRun : (optional) cleans up the application after the run\n" +
-    "--cli : (optional) A path to Cordova CLI\n" +
-    "--config : (optional) read configuration from paramedic configuration file\n" +
-    "--fileTransferServer : (optional) (cordova-plugin-file-transfer only) A server address tests should connect to\n" +
-    "--justbuild : (optional) just builds the project, without running the tests \n" +
-    "--logMins : (optional) Windows only - specifies number of minutes to get logs\n" +
-    "--outputDir : (optional) path to save Junit results file & Device logs\n" +
-    "--sauceAppiumVersion : (optional) Appium version to use when running on Saucelabs. For example, \"1.5.3\"\n" +
-    "--sauceDeviceName : (optional) Name of the SauceLabs emulator/browser. For example, \"iPhone Simulator\" or \"firefox\"\n" +
-    "--sauceKey : (optional) Saucelabs access key\n" +
-    "--saucePlatformVersion : (optional) Version of the emulator OS or version of the browser. For example, \"9.3\" or \"54.0\"\n" +
-    "--sauceTunnelId : (optional) Tunnel identifier to use. Only usable if you have Sauce Connect up\n" + 
-    "--sauceUser : (optional) Saucelabs username\n" +
-    "--shouldUseSauce : (optional) run tests on Sauce Labs\n" +
-    "--skipAppiumTests : (optional) Do not run Appium tests\n" +
-    "--skipMainTests : (optional) Do not run main (cordova-test-framework) tests\n" +
-    "--startport/--endport `PORTNUM` : (optional) ports to find available and use for posting results from emulator back to paramedic server (default is from 8008 to 8009)\n" +
-    "--target : (optional) target to deploy to\n" +
-    "--tccDb : (optional) iOS only - specifies the path for the TCC.db file to be copied.\n" +
-    "--timeout `MSECS` : (optional) time in millisecs to wait for tests to pass|fail \n" +
-                "\t(defaults to 10 minutes) \n" +
-    "--useTunnel: (optional) use tunneling instead of local address. default is false\n" +
-    "--verbose : (optional) verbose mode. Display more information output\n" +
-    "--version : (optional) prints cordova-paramedic version and exits\n" +
-    "";
+                    '\tYou may specify multiple --plugin flags and they will all\n' +
+                    '\tbe installed and tested together.\n' +
+    '\n' +
+    'Alphabetical list of optional parameters:\n' +
+    '--action: TODO\n' +
+    '--args: add command line args to the "cordova build" and "cordov run" commands \n' +
+    '--buildName : Build name to show in Saucelabs dashboard\n' +
+    '--ci :  Skip tests that require user interaction\n' +
+    '--cleanUpAfterRun : cleans up the application after the run\n' +
+    '--cli : A path to Cordova CLI\n' +
+    '--config : read configuration from paramedic configuration file\n' +
+    '--externalServerUrl :  TODO\n' +
+    '--fileTransferServer : (cordova-plugin-file-transfer only) A server address tests should connect to\n' +
+    '--justbuild : just builds the project, without running the tests \n' +
+    '--logMins : Windows only - specifies number of minutes to get logs\n' +
+    '--outputDir : path to save Junit results file & Device logs\n' +
+    '--port : TODO\n' +
+    '--sauceAppiumVersion : Appium version to use when running on Saucelabs. For example, "1.5.3"\n' +
+    '--sauceDeviceName : Name of the SauceLabs emulator/browser. For example, "iPhone Simulator" or "firefox"\n' +
+    '--sauceKey : Saucelabs access key\n' +
+    '--saucePlatformVersion : Version of the emulator OS or version of the browser. For example, "9.3" or "54.0"\n' +
+    '--sauceTunnelId : Tunnel identifier to use. Only usable if you have Sauce Connect up\n' +
+    '--sauceUser : Saucelabs username\n' +
+    '--shouldUseSauce : run tests on Sauce Labs\n' +
+    '--skipAppiumTests : Do not run Appium tests\n' +
+    '--skipMainTests : Do not run main (cordova-test-framework) tests\n' +
+    '--startport/--endport `PORTNUM` : ports to find available and use for posting results from emulator back to paramedic server (default is from 8008 to 8009)\n' +
+    '--target : target to deploy to\n' +
+    '--tccDb : iOS only - specifies the path for the TCC.db file to be copied.\n' +
+    '--timeout `MSECS` : time in millisecs to wait for tests to pass|fail \n' +
+                '\t(defaults to 10 minutes) \n' +
+    '--useTunnel: use tunneling instead of local address. default is false\n' +
+    '--verbose : verbose mode. Display more information output\n' +
+    '--version : prints cordova-paramedic version and exits\n' +
+    '';
 
 var argv = parseArgs(process.argv.slice(2), {
-    "string": ["plugin"]
+    'string': ['plugin']
 });
 var pathToParamedicConfig = util.getConfigPath(argv.config);
 
@@ -77,39 +81,84 @@ if (argv.version) {
     console.log(require('./package.json')['version']);
     process.exit(0);
 } else if (pathToParamedicConfig || // --config
-    argv.platform && argv.plugin) { // or --platform and --plugin
+    (argv.platform && argv.plugin)) { // or --platform and --plugin
 
     var paramedicConfig = pathToParamedicConfig ?
-        ParamedicConfig.parseFromFile(pathToParamedicConfig):
+        ParamedicConfig.parseFromFile(pathToParamedicConfig) :
         ParamedicConfig.parseFromArguments(argv);
 
-    if (argv.justBuild || argv.justbuild) {
-        paramedicConfig.setAction('build');
+    // What and how to build and test
+
+    if (argv.platform) {
+        paramedicConfig.setPlatform(argv.platform);
     }
 
     if (argv.plugin) {
         paramedicConfig.setPlugins(argv.plugin);
     }
 
-    if (argv.outputDir) {
-        paramedicConfig.setOutputDir(argv.outputDir);
+    if (argv.cli) {
+        paramedicConfig.setCli(argv.cli);
     }
 
-    if (argv.logMins) {
-        paramedicConfig.setLogMins(argv.logMins);
-    }
-
-    if (argv.tccDb){
-        paramedicConfig.setTccDb(argv.tccDb);
-    }
-
-    if (argv.platform) {
-        paramedicConfig.setPlatform(argv.platform);
+    if (argv.justBuild || argv.justbuild) {
+        paramedicConfig.setAction('build');
     }
 
     if (argv.action) {
         paramedicConfig.setAction(argv.action);
     }
+
+    if (argv.skipMainTests) {
+        paramedicConfig.setSkipMainTests(argv.skipMainTests);
+    }
+
+    if (argv.skipAppiumTests) {
+        paramedicConfig.setSkipAppiumTests(argv.skipAppiumTests);
+    }
+
+    if (argv.args) {
+        paramedicConfig.setArgs(argv.args);
+    }
+
+    // Emulator/Device to use for tests
+
+    if (argv.target) {
+        paramedicConfig.setTarget(argv.target);
+    }
+
+    // Test Result Server
+
+    if (argv.useTunnel) {
+        if (argv.useTunnel === 'false') {
+            argv.useTunnel = false;
+        }
+        paramedicConfig.setUseTunnel(argv.useTunnel);
+    }
+
+    // externalServerUrl?
+
+    // port?
+
+    // Test configuration
+
+    // timeout?
+
+    if (argv.outputDir) {
+        paramedicConfig.setOutputDir(argv.outputDir);
+    }
+
+    // cleanUpAfterRun?
+
+    if (argv.logMins) {
+        paramedicConfig.setLogMins(argv.logMins);
+    }
+
+    if (argv.tccDb) {
+        paramedicConfig.setTccDb(argv.tccDb);
+    }
+
+    // Sauce Labs
 
     if (argv.shouldUseSauce) {
         if (argv.shouldUseSauce === 'false') {
@@ -118,16 +167,16 @@ if (argv.version) {
         paramedicConfig.setShouldUseSauce(argv.shouldUseSauce);
     }
 
-    if (argv.buildName) {
-        paramedicConfig.setBuildName(argv.buildName);
-    }
-
     if (argv.sauceUser) {
         paramedicConfig.setSauceUser(argv.sauceUser);
     }
 
     if (argv.sauceKey) {
         paramedicConfig.setSauceKey(argv.sauceKey);
+    }
+
+    if (argv.buildName) {
+        paramedicConfig.setBuildName(argv.buildName);
     }
 
     if (argv.sauceDeviceName) {
@@ -146,56 +195,33 @@ if (argv.version) {
         paramedicConfig.setSauceTunnelId(argv.sauceTunnelId);
     }
 
-    if (argv.useTunnel) {
-        if (argv.useTunnel === 'false') {
-            argv.useTunnel = false;
-        }
-        paramedicConfig.setUseTunnel(argv.useTunnel);
-    }
-
-    if (argv.skipMainTests) {
-        paramedicConfig.setSkipMainTests(argv.skipMainTests);
-    }
-
-    if (argv.skipAppiumTests) {
-        paramedicConfig.setSkipAppiumTests(argv.skipAppiumTests);
-    }
+    // Others
 
     if (argv.ci) {
         paramedicConfig.setCI(argv.ci);
-    }
-
-    if (argv.target) {
-        paramedicConfig.setTarget(argv.target);
     }
 
     if (argv.fileTransferServer) {
         paramedicConfig.setFileTransferServer(argv.fileTransferServer);
     }
 
-    if (argv.cli) {
-        paramedicConfig.setCli(argv.cli);
-    }
-
-    if (argv.args) {
-        paramedicConfig.setArgs(argv.args);
-    }
+    // run!
 
     paramedic.run(paramedicConfig)
-    .catch(function (error) {
-        if (error && error.stack) {
-            console.error(error.stack);
-        } else if (error) {
-            console.error(error);
-        }
-        process.exit(1);
-    })
-    .done(function(isTestPassed) {
-        var exitCode = isTestPassed ? 0 : 1;
+        .catch(function (error) {
+            if (error && error.stack) {
+                console.error(error.stack);
+            } else if (error) {
+                console.error(error);
+            }
+            process.exit(1);
+        })
+        .done(function (isTestPassed) {
+            var exitCode = isTestPassed ? 0 : 1;
 
-        console.log('Finished with exit code ' + exitCode);
-        process.exit(exitCode);
-    });
+            console.log('Finished with exit code ' + exitCode);
+            process.exit(exitCode);
+        });
 
 } else {
     console.log(USAGE);


### PR DESCRIPTION
add missing params to README
resort params before run to match README
resort params in README with new knowledge what they do
fix eslint stuff for main.js
resort params in ParamedicConfig.parseFromArguments in same order as README as well

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
