### PR TITLE
ci: node 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ addons:
 env:
   global:
     - SAUCE_USERNAME=snay
-    - TRAVIS_NODE_VERSION=8
+    - TRAVIS_NODE_VERSION=12
     - ANDROID_API_LEVEL=28
     - ANDROID_BUILD_TOOLS_VERSION=28.0.3
 
 language: node_js
-node_js: 8
+node_js: 12
 
 # yaml anchor/alias: https://medium.com/@tommyvn/travis-yml-dry-with-anchors-8b6a3ac1b027
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-paramedic",
-  "version": "0.6.0-dev",
+  "version": "1.0.0-dev",
   "license": "Apache-2.0",
   "description": "Use medic to test a cordova plugin locally",
   "main": "paramedic.js",


### PR DESCRIPTION
Let's push node to what is currently possible, then roll that out to all plugins (node on CI is only used for testing, thus is not a breaking change for the plugins). This should us give a few months or years until we have to do that again, but can really use all the modern stuff.

Note that this PR only changes the node version used on CI, and doesn't change the code at all - that will happen with further PRs. But as this is the start of major breaking changes, I decided to +1 the major version here as well.