### PR TITLE
Add a new option deploymentIosTarget (ios)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ For iOS: A string that is used to pick the device (from the `cordova run --list 
 cordova-paramedic --platform ios --plugin cordova-plugin-contacts --target "iPhone-8"
 ```
 
+#### `--deploymentIosTarget` (optional)
+
+For iOS: if the plugin requires a minimum version of iOS. This parameter is going to add `<preference name="deployment-target" value="${deploymentIosTarget}" />`on the `config.xml`.
+
+```
+cordova-paramedic --platform ios --plugin cordova-plugin-contacts --target "iPhone-8" --deploymentIosTarget="10.0"
+```
+
 
 ### Test Result Server
 

--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -101,6 +101,7 @@ class ParamedicApp {
         return execPromise(this.config.getCli() + ' platform add ' + platform + utilities.PARAMEDIC_COMMON_CLI_ARGS + utilities.PARAMEDIC_PLATFORM_ADD_ARGS)
             .then(() => {
                 logger.info('cordova-paramedic: successfully finished adding platform ' + platform);
+
                 if (this.isAndroid && this.config.isCI()) {
                     logger.info('cordova-paramedic: monkey patching Android platform to disable gradle daemon...');
                     const gradleBuilderFile = path.join(this.tempFolder.name, 'platforms', 'android', 'cordova', 'lib', 'builders', 'GradleBuilder.js');
@@ -128,8 +129,18 @@ class ParamedicApp {
                             this.runner.browserPatched = false;
                         }
                     }
+                } else if (this.isIos) {
+                    this.setUpDeploymentIosTarget();
                 }
             });
+    }
+
+    setUpDeploymentIosTarget () {
+        const deploymentIosTarget = this.config.getDeploymentIosTarget();
+        if (deploymentIosTarget) {
+            shell.sed('-i', '<platform name="ios">', `<platform name="ios">\\n\\t<preference name="deployment-target" value="${deploymentIosTarget}" />`, 'config.xml');
+            logger.info(`cordova-paramedic: set up minimum deployment ios target ${deploymentIosTarget}`);
+        }
     }
 
     checkPlatformRequirements () {

--- a/lib/ParamedicConfig.js
+++ b/lib/ParamedicConfig.js
@@ -276,6 +276,14 @@ class ParamedicConfig {
         this._config.cli = cli;
     }
 
+    getDeploymentIosTarget () {
+        return this._config.deploymentIosTarget ? this._config.deploymentIosTarget : undefined;
+    }
+
+    setDeploymentIosTarget (deploymentIosTarget) {
+        this._config.deploymentIosTarget = deploymentIosTarget;
+    }
+
     getAll () {
         return this._config;
     }

--- a/main.js
+++ b/main.js
@@ -66,6 +66,7 @@ var USAGE           = "Error missing args. \n" +
     "--useTunnel: (optional) use tunneling instead of local address. default is false\n" +
     "--verbose : (optional) verbose mode. Display more information output\n" +
     "--version : (optional) prints cordova-paramedic version and exits\n" +
+    "--deploymentIosTarget: (optional) Adds a minimum ios deployment target on config.xml\n" +
     "";
 
 var argv = parseArgs(process.argv.slice(2), {
@@ -179,6 +180,10 @@ if (argv.version) {
 
     if (argv.args) {
         paramedicConfig.setArgs(argv.args);
+    }
+
+    if (argv.deploymentIosTarget) {
+        paramedicConfig.setDeploymentIosTarget(argv.deploymentIosTarget);
     }
 
     paramedic.run(paramedicConfig)


### PR DESCRIPTION
If is set ios platform and deploymentIosTarget is going to add the following field `<preference name="deployment-target" value="${deploymentIosTarget}" />`on the `config.xml`.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] I've updated the documentation if necessary
