### PR TITLE
fix: install platform before plugin so platform-specific preferences are included

### DIFF
--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -56,10 +56,12 @@ class ParamedicApp {
     }
 
     prepareProjectToRunTests () {
-        this.installPlugins();
-        this.setUpStartPage();
         return this.installPlatform()
-            .then(() => this.checkPlatformRequirements());
+            .then(() => {
+              this.installPlugins();
+              this.setUpStartPage();
+              this.checkPlatformRequirements()
+            });
     }
 
     installPlugins () {


### PR DESCRIPTION
### Platforms affected

All platforms.


### Motivation and Context
If the plugin is installed before the platform, cordova will not populate the default preference values specified by the plugin. In cases where the preference is a mandatory value, this can cause the plugin to fail to build.



### Description
Re-ordered the setup commands so it's now platform, then plugin etc.

### Testing
I've ensured that a plugin with default preferences (e.g., https://github.com/don/cordova-plugin-ble-central) has these preferences appear in the generated config.xml and package.json files in the test app that cordova-paramedic generates.



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
