### PR TITLE
breaking: use latest platform & development tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ node_js: 12
 
 _ios: &_ios
   os: osx
-  osx_image: xcode10.3
+  osx_image: xcode11.5
 
 _android: &_android
   language: android

--- a/conf/pr/browser-chrome.config.json
+++ b/conf/pr/browser-chrome.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "browser",
+    "platform": "browser@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/browser-edge.config.json
+++ b/conf/pr/browser-edge.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "browser",
+    "platform": "browser@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/browser-firefox.config.json
+++ b/conf/pr/browser-firefox.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "browser",
+    "platform": "browser@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/browser-safari.config.json
+++ b/conf/pr/browser-safari.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "browser",
+    "platform": "browser@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/ios-11.3.config.json
+++ b/conf/pr/ios-11.3.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "ios",
+    "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/ios-12.0.config.json
+++ b/conf/pr/ios-12.0.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "ios",
+    "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/ios-12.2.config.json
+++ b/conf/pr/ios-12.2.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "ios",
+    "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/local/browser.config.json
+++ b/conf/pr/local/browser.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "browser",
+    "platform": "browser@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "verbose": true

--- a/conf/pr/local/ios-10.0.config.json
+++ b/conf/pr/local/ios-10.0.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "ios",
+    "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "target": "iPhone-XR",

--- a/conf/pr/local/ios-10.0.config.json
+++ b/conf/pr/local/ios-10.0.config.json
@@ -2,6 +2,6 @@
     "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "iPhone-XR",
+    "target": "iPhone-11",
     "verbose": true
 }

--- a/conf/pr/local/ios-9.3.config.json
+++ b/conf/pr/local/ios-9.3.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "ios@4.5.5",
+    "platform": "ios@latest",
     "args": "--buildFlag='-UseModernBuildSystem=0'",
     "action": "run",
     "cleanUpAfterRun": true,

--- a/conf/pr/local/windows-10-store.config.json
+++ b/conf/pr/local/windows-10-store.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "windows",
+    "platform": "windows@latest",
     "action": "run",
     "args": " -- --appx=uap --archs=x64",
     "cleanUpAfterRun": true,

--- a/conf/pr/windows-10-store.config.json
+++ b/conf/pr/windows-10-store.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "windows",
+    "platform": "windows@latest",
     "action": "run",
     "args": " -- --appx=uap --archs=x64",
     "cleanUpAfterRun": true,

--- a/sample-config/.paramedic.config.js
+++ b/sample-config/.paramedic.config.js
@@ -24,7 +24,7 @@ module.exports = {
     "plugins": [
         "https://github.com/apache/cordova-plugin-inappbrowser"
     ],
-     "platform": "windows",
+     "platform": "windows@latest",
      "action": "run",
      "args": "--archs=x64 -- --appx=uap"
 };


### PR DESCRIPTION
### Motivation, Context & Description

IMO when the plugins are tested it might be best to test against the latest release even if the CLI/Lib pinning has not been updated.

This PR updates the platform to use `@latest` to ensure that npm installs the latest release and not the pinned version from `cordova-lib`.

Additionally, to be inline with the current `@latest` platforms, the development environment & tools were updated.
