### PR TITLE
breaking: use latest android platform & development tools 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ env:
   global:
     - SAUCE_USERNAME=snay
     - TRAVIS_NODE_VERSION=12
-    - ANDROID_API_LEVEL=28
-    - ANDROID_BUILD_TOOLS_VERSION=28.0.3
+    - ANDROID_API_LEVEL=29
+    - ANDROID_BUILD_TOOLS_VERSION=29.0.2
 
 language: node_js
 node_js: 12

--- a/conf/pr/android-4.4.config.json
+++ b/conf/pr/android-4.4.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "android",
+    "platform": "android@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/android-5.1.config.json
+++ b/conf/pr/android-5.1.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "android",
+    "platform": "android@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/android-6.0.config.json
+++ b/conf/pr/android-6.0.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "android",
+    "platform": "android@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/android-7.0.config.json
+++ b/conf/pr/android-7.0.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "android",
+    "platform": "android@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/android-7.1.config.json
+++ b/conf/pr/android-7.1.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "android",
+    "platform": "android@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/android-8.0.config.json
+++ b/conf/pr/android-8.0.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "android",
+    "platform": "android@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/android-8.1.config.json
+++ b/conf/pr/android-8.1.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "android",
+    "platform": "android@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/android-9.0.config.json
+++ b/conf/pr/android-9.0.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "android",
+    "platform": "android@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "shouldUseSauce": true,

--- a/conf/pr/local/android-4.4.config.json
+++ b/conf/pr/local/android-4.4.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "android",
+    "platform": "android@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "target": "api19",

--- a/conf/pr/local/android-5.1.config.json
+++ b/conf/pr/local/android-5.1.config.json
@@ -1,5 +1,5 @@
 {
-    "platform": "android",
+    "platform": "android@latest",
     "action": "run",
     "cleanUpAfterRun": true,
     "target": "api22",


### PR DESCRIPTION
### Motivation, Context & Description

IMO when the plugins are tested it might be best to test against the latest release even if the CLI/Lib pinning has not been updated.

This PR updates the cordova-android platform to use `@latest` to ensure that npm installs the latest release and not the pinned version from `cordova-lib`.

Additionally, to be inline with the current `android@latest` platform, the development environment & tools were updated.
