### PR TITLE
tmp: use cordova-plugin-test-framework master repo

### DIFF
--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -68,7 +68,7 @@ class ParamedicApp {
         pluginsManager.installPlugins(this.config.getPlugins());
         pluginsManager.installTestsForExistingPlugins();
 
-        let additionalPlugins = ['cordova-plugin-test-framework', path.join(__dirname, '..', 'paramedic-plugin')];
+        let additionalPlugins = ['github:apache/cordova-plugin-test-framework', path.join(__dirname, '..', 'paramedic-plugin')];
 
         if (this.config.shouldUseSauce() && !this.config.getUseTunnel()) {
             additionalPlugins.push(path.join(__dirname, '..', 'event-cache-plugin'));


### PR DESCRIPTION
### Motivation, Context & Description

This is to get tests passing for iOS temporarily while we work on the release for `cordova-plugin-test-framework`
There could be other future changes to `cordova-plugin-test-framework` while working on the rest of the issues. Would be nice to not hinder plugin testing if possible while trying to resolve the remaining issues.

This change will be reverted back to an official release after all issues are resolved and the framework release is complete.
