### PR TITLE
(android) reference emulator from node_modules

### DIFF
--- a/lib/ParamedicTargetChooser.js
+++ b/lib/ParamedicTargetChooser.js
@@ -68,7 +68,10 @@ class ParamedicTargetChooser {
     startAnAndroidEmulator (target) {
         logger.info('cordova-paramedic: Starting an Android emulator');
 
-        const emuPath = path.join(this.appPath, 'platforms', 'android', 'cordova', 'lib', 'emulator');
+        const emuPathInNodeModules = path.join(this.appPath, 'node_modules', 'cordova-android', 'lib', 'emulator.js');
+        const emuPathInPlatform = path.join(this.appPath, 'platforms', 'android', 'cordova', 'lib', 'emulator.js');
+
+        const emuPath = utilities.doesFileExist(emuPathInNodeModules) ? emuPathInNodeModules : emuPathInPlatform;
         const emulator = require(emuPath);
 
         const tryStart = (numberTriesRemaining) => {


### PR DESCRIPTION
### Platforms affected
- Android when using cordova-android@10+

### Motivation and Context
https://github.com/apache/cordova-android/pull/1269
- Due to https://github.com/apache/cordova-android/pull/1269 - The emulator script being referenced no longer exists so an alternative needs to be used. I referenced the emulator script from the node_modules folder
  - Without this change `cordova-paramedic` run using platform android@10.0.0 will error due to this file not found

### Description
Since the `emulator` script is no longer copied into the platform, this updates the path to reference the script in the `node_modules` folder

### Testing
I have run the `cordova-paramedic` command targeting android and the file not found error is resolved.
This has been run targeting android@10.1.0 on macos@11.4 and using GitHub Actions.
Backwards compatibility (pre android@10) has been confirmed to work by running `npm test`

- cordova-plugin-statusbar has been used to confirm with a plugin https://github.com/SwitchCaseGroup/cordova-plugin-statusbar/actions/runs/1168154209

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
