### PR TITLE
feat!: bump node engine requirement >=12

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cordova-paramedic": "./main.js"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=12"
   },
   "repository": "github:apache/cordova-paramedic",
   "bugs": "https://github.com/apache/cordova-paramedic/issues",


### PR DESCRIPTION
### Motivation and Context

Bump node engine requirement to the maintained-LTS version.

* `>=12`
