### PR TITLE
test(paramedic-plugin): update edit-config for various plugin support

### DIFF
--- a/paramedic-plugin/plugin.xml
+++ b/paramedic-plugin/plugin.xml
@@ -50,9 +50,11 @@
         <!-- <preference name="localhost" value="apptest.cordova.apache.org" /> -->
       </config-file>
 
-      <edit-config file="AndroidManifest.xml" target="/manifest/application" mode="merge">
+      <edit-config file="AndroidManifest.xml" target="/manifest/application" mode="overwrite">
         <!-- Cleartext Traffic should be avoided. Currently the way paramedic proxy the results, cleartext is needed, even when the scheme is set to http. -->
-        <application android:usesCleartextTraffic="true" />
+        <application
+          android:requestLegacyExternalStorage="true"
+          android:usesCleartextTraffic="true" />
       </edit-config>
     </platform>
 </plugin>


### PR DESCRIPTION
### Platforms affected

Android

### Motivation and Context

Make tests green.

### Description

Set on AndroidManifest:

```
<application
          android:requestLegacyExternalStorage="true"
          android:usesCleartextTraffic="true" />
```

### Testing

- GitHub Actions Test Results.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
