### PR TITLE
ci(ios): corrected version matrix & pr configs

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   test:
     name: iOS ${{ matrix.versions.ios-version }} Test
-    runs-on: macos-latest
+    runs-on: ${{ matrix.versions.os-version }}
 
     # hoist configurations to top that are expected to be updated
     env:
@@ -49,9 +49,17 @@ jobs:
     strategy:
       matrix:
         versions:
-          - ios-version: 12.x
-          - ios-version: 13.x
-          - ios-version: 14.x
+          - os-version: macos-10.15
+            ios-version: 12.x
+            xcode-version: 11.x
+
+          - os-version: macos-10.15
+            ios-version: 13.x
+            xcode-version: 11.x
+
+          - os-version: macos-10.15
+            ios-version: 14.x
+            xcode-version: 12.x
 
     steps:
       - uses: actions/checkout@v2
@@ -74,6 +82,12 @@ jobs:
         run: |
           npm i -g cordova@latest ios-deploy@latest
           npm ci
+
+      - name: Run setup iOS 12.x support
+        if: ${{ matrix.versions.ios-version == '12.x' }}
+        run: |
+          sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
+          sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 12.4.simruntime
 
       - name: Run paramedic install
         if: ${{ endswith(env.repo, '/cordova-paramedic')　!= true }}

--- a/conf/pr/local/ios-12.x.config.json
+++ b/conf/pr/local/ios-12.x.config.json
@@ -2,6 +2,6 @@
     "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "iPhone-11, 12.5.4",
+    "target": "iPhone-8, 12.4",
     "verbose": true
 }

--- a/conf/pr/local/ios-14.x.config.json
+++ b/conf/pr/local/ios-14.x.config.json
@@ -2,6 +2,6 @@
     "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "iPhone-11, 14.7.1",
+    "target": "iPhone-12, 14.4",
     "verbose": true
 }


### PR DESCRIPTION
### Platforms affected

iOS

### Motivation, Context & Description

* Correct the version matrix for iOS workflow.
* Updated the iOS local PR configs with valid Simulators that exist on GH Actions
* Fixes the issue where all iOS tests ran off the `iPhone-8 14.4` simulator.

This PR extracts all of the CI configuration changes & iOS local PR config changes that I did in my own repo's internal PR: https://github.com/erisu/cordova-paramedic/pull/14/files

This PR excludes iOS 15.x related changes that were in the above PR.

### Testing

- Ran in GitHub Actions CI

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
