### PR TITLE
chore: add hacktoberfest label

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,6 +15,24 @@
 # specific language governing permissions and limitations
 # under the License.
 
+github:
+  description: "Apache Cordova - Paramedic"
+  homepage: https://cordova.apache.org/
+  labels:
+    - cordova
+    - cplusplus
+    - csharp
+    - hacktoberfest
+    - java
+    - javascript
+    - library
+    - mobile
+    - nodejs
+    - objective-c
+
+  features:
+    issues: true
+
 notifications:
   commits:              commits@cordova.apache.org
   issues:               issues@cordova.apache.org


### PR DESCRIPTION
- Add repo's exisiting description & labels to the asf configuration file.
- Add `hacktoberfest` label