### PR TITLE
feat!: ability to choose temporary directory (#231)

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,14 @@ Directory location to store test results in junit format and the device logs
 cordova-paramedic --platform ios --plugin cordova-plugin-inappbrowser --outputDir /Users/sampleuser/testresults
 ```
 
+#### `--tmpDir` (optional)
+
+A path to a temporary directory where a project will be built. It points to a system temporary directory by default.
+
+```shell
+cordova-paramedic --platform ios --plugin cordova-plugin-inappbrowser --tmpDir ../tmp
+```
+
 #### `--cleanUpAfterRun` (optional)
 
 Flag to indicate the sample application folder must be deleted.

--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -48,7 +48,7 @@ class ParamedicApp {
     }
 
     createTempProject () {
-        this.tempFolder = tmp.dirSync();
+        this.tempFolder = tmp.dirSync({ tmpdir: this.config.getTmpDir() });
         tmp.setGracefulCleanup();
         logger.info('cordova-paramedic: creating temp project at ' + this.tempFolder.name);
         exec(this.config.getCli() + ' create ' + this.tempFolder.name + utilities.PARAMEDIC_COMMON_CLI_ARGS);

--- a/lib/ParamedicConfig.js
+++ b/lib/ParamedicConfig.js
@@ -71,6 +71,14 @@ class ParamedicConfig {
         this._config.outputDir = outputDir;
     }
 
+    getTmpDir () {
+        return this._config.tmpDir;
+    }
+
+    setTmpDir (tmpDir) {
+        this._config.tmpDir = tmpDir;
+    }
+
     shouldCleanUpAfterRun () {
         return this._config.cleanUpAfterRun;
     }
@@ -293,6 +301,7 @@ ParamedicConfig.parseFromArguments = function (argv) {
         endPort: argv.endport || argv.port,
         externalServerUrl: argv.externalServerUrl,
         outputDir: argv.outputDir ? argv.outputDir : null,
+        tmpDir: argv.tmpDir,
         logMins: argv.logMins ? argv.logMins : null,
         tccDb: argv.tccDbPath ? argv.tccDb : null,
         cleanUpAfterRun: !!argv.cleanUpAfterRun,


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
The change affects a building process not target platforms.


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes the ability to choose temporary directory request (#231)


### Description
<!-- Describe your changes in detail -->
I've added new configuration parameter --tmpDir to choose temporary directory.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I've run tests with and without --tmpDir parameter. Projects are still creating in the system tmp directory without --tmpDir parameter configured.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
