### PR TITLE
ci(ios): drop macos 10.15 & iOS 12

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -49,15 +49,11 @@ jobs:
     strategy:
       matrix:
         versions:
-          - os-version: macos-10.15
-            ios-version: 12.x
-            xcode-version: 11.x
-
-          - os-version: macos-10.15
+          - os-version: macos-11
             ios-version: 13.x
             xcode-version: 11.x
 
-          - os-version: macos-10.15
+          - os-version: macos-11
             ios-version: 14.x
             xcode-version: 12.x
 
@@ -87,19 +83,8 @@ jobs:
           npm i -g cordova@latest ios-deploy@latest
           npm ci
 
-      # Starting from Cordova-iOS 6.1, Xcode 11.x or higher is required for a successful build.
-      # By default, the Xcode 11.x app comes with the iOS 13.x.
-      # To continue testing iOS 12.x, we create a symbolic link to the iOS 12.4 Simulator Runtime.
-      # This simulator runtime is located in the Xcode 10.3 app that is preinstalled with the
-      # GitHub’s macOS 10.15 image.
-      - name: Run setup iOS 12.x support
-        if: ${{ matrix.versions.ios-version == '12.x' }}
-        run: |
-          sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
-          sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 12.4.simruntime
-
       - name: Run paramedic install
-        if: ${{ endswith(env.repo, '/cordova-paramedic')　!= true }}
+        if: ${{ endswith(env.repo, '/cordova-paramedic') != true }}
         run: npm i -g github:apache/cordova-paramedic
 
       - name: Run paramedic tests


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

none

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

> The macOS 10.15 Actions runner image [started our deprecation process](http://app.github.media/e/er?s=88570519&lid=3339&elqTrackId=f7a2ee0f7fb04d009f301a8990fdc3a7&elq=e5f8577314b546cebad4e5512f96dc02&elqaid=2633&elqat=1) on 5/31/22 and will be fully unsupported by 8/30/22.

### Description
<!-- Describe your changes in detail -->

Remove macOS 10.15 from the workflow.

This also removes iOS 12 from the testing matrix.

### Testing
<!-- Please describe in detail how you tested your changes. -->

See Action Results

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
