### PR TITLE
Fix url of cordova-plugin-test-framework to speed up adding plugin

### DIFF
--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -70,7 +70,7 @@ class ParamedicApp {
         pluginsManager.installPlugins(this.config.getPlugins());
         pluginsManager.installTestsForExistingPlugins();
 
-        const additionalPlugins = ['github:apache/cordova-plugin-test-framework', path.join(__dirname, '..', 'paramedic-plugin')];
+        const additionalPlugins = ['https://github.com/apache/cordova-plugin-test-framework.git', path.join(__dirname, '..', 'paramedic-plugin')];
 
         if (this.config.shouldUseSauce() && !this.config.getUseTunnel()) {
             additionalPlugins.push(path.join(__dirname, '..', 'event-cache-plugin'));


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

Closes #239 


### Platforms affected
All


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
The stage in the cordova-paramedic command where the cordova-plugin-test-framework plugin is being added was taking a very long time with the previous link (around 10 minutes or so). Now, with the fixed link, it is added within seconds.


### Description
<!-- Describe your changes in detail -->
This PR simply changes the link of the cordova-plugin-test-framework plugin.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I have tested running the cordova-paramedic for both Android and iOS platforms with the above changes. The add plugins stage still works and now it installs the cordova-plugin-test-framework much faster.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
