### PR TITLE
ci(ios): add continue-on-error flag

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -33,6 +33,7 @@ jobs:
   test:
     name: iOS ${{ matrix.versions.ios-version }} Test
     runs-on: ${{ matrix.versions.os-version }}
+    continue-on-error: true
 
     # hoist configurations to top that are expected to be updated
     env:


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

N/A

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Add the `continue-on-error` flag to allow all tests to run even if one fails.

Sometimes failures are caused by a timeout. Timeouts should not terminate all tests.  

Also matches with Android config.

### Description
<!-- Describe your changes in detail -->

Set `continue-on-error` to `true`.

### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
