### PR TITLE
fix(android): change order of project setup & plugin install

### DIFF
--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -67,28 +67,32 @@ class ParamedicApp {
     installPlugins () {
         logger.info('cordova-paramedic: installing plugins');
         const pluginsManager = new PluginsManager(this.tempFolder.name, this.storedCWD, this.config);
-        pluginsManager.installPlugins(this.config.getPlugins());
-        pluginsManager.installTestsForExistingPlugins();
 
-        const additionalPlugins = ['github:apache/cordova-plugin-test-framework', path.join(__dirname, '..', 'paramedic-plugin')];
+        const ciFrameworkPlugins = ['github:apache/cordova-plugin-test-framework', path.join(__dirname, '..', 'paramedic-plugin')];
 
         if (this.config.shouldUseSauce() && !this.config.getUseTunnel()) {
-            additionalPlugins.push(path.join(__dirname, '..', 'event-cache-plugin'));
+            ciFrameworkPlugins.push(path.join(__dirname, '..', 'event-cache-plugin'));
         }
 
         if (this.isWindows) {
-            additionalPlugins.push(path.join(__dirname, '..', 'debug-mode-plugin'));
+            ciFrameworkPlugins.push(path.join(__dirname, '..', 'debug-mode-plugin'));
         }
 
         if (this.isIos) {
-            additionalPlugins.push(path.join(__dirname, '..', 'ios-geolocation-permissions-plugin'));
+            ciFrameworkPlugins.push(path.join(__dirname, '..', 'ios-geolocation-permissions-plugin'));
         }
 
         if (this.config.isCI()) {
-            additionalPlugins.push(path.join(__dirname, '..', 'ci-plugin'));
+            ciFrameworkPlugins.push(path.join(__dirname, '..', 'ci-plugin'));
         }
 
-        pluginsManager.installPlugins(additionalPlugins);
+        // Install testing framework
+        logger.info('cordova-paramedic: installing ci framework plugins: ' + ciFrameworkPlugins.join(', '));
+        pluginsManager.installPlugins(ciFrameworkPlugins);
+        logger.info('cordova-paramedic: installing plugins:' + this.config.getPlugins().join(', '));
+        pluginsManager.installPlugins(this.config.getPlugins());
+        logger.info('cordova-paramedic: installing tests for existing plugins');
+        pluginsManager.installTestsForExistingPlugins();
     }
 
     setUpStartPage () {

--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -56,9 +56,9 @@ class ParamedicApp {
     }
 
     prepareProjectToRunTests () {
-        this.installPlugins();
-        this.setUpStartPage();
         return this.installPlatform()
+            .then(() => this.installPlugins())
+            .then(() => this.setUpStartPage())
             .then(() => this.checkPlatformRequirements())
             .then(() => this.checkDumpAndroidManifest())
             .then(() => this.checkDumpAndroidConfigXml());


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Various Android tests are failing because of the config munging order.

This PR changes the order of the project setup and the plugin install as a temporary workaround for Android plugin testing.

This change does not resolve the underlining issue.

### Description
<!-- Describe your changes in detail -->

#### Example issue

**Current Order of Paramedic for Reference:**

* Install Plugins
  * Install Plugins
  * Install Test For Existing Plugins
  * Install CI Testing Framework Related Plugins
* Setup Project Config For Test Framework
* Install Platform

Some plugins and the test plugins will inject elements into the `AndroidManifest` with `config-file`. For example, let us say the `provider` node is injected into the path of `/manifest/application`.

Next, the CI testing plugin attempts to update the `/manifest/application` node by appending attributes with `edit-config`.

Because the CI is trying to update the same node that had already been modified with `config-file`, it fails to merge with conflicts, even if the changes do not affect each other.

#### Example Solution

**New Order of Paramedic for Reference:**

* Install Platform
* Install Plugins
  * Install CI Testing Framework Related Plugins
  * Install Plugins
  * Install Test For Existing Plugins
* Setup Project Config For Test Framework

If `edit-config` is applied first and then `config-file` is applied last, will not fail because config-file only uses the node path as a reference to where it needs to inject.

#### Final Note

Even though we change the order for the paramedic to resolve the issue, it only tests as if the project was being built up from scratch.

If we looked at the issue from a CI perspective, all the plugins and platforms are usually defined in `package.json`, and running `cordova prepare` could trigger the same issue as the order for installation might not be guaranteed.

More investigation into a proper solution should be performed within the `cordova-common` repo.

### Testing
<!-- Please describe in detail how you tested your changes. -->

* GitHub Action CI

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
