### PR TITLE
fix: cli 12 requires platform name w/ cordova run --list

### DIFF
--- a/conf/pr/local/ios-13.x.config.json
+++ b/conf/pr/local/ios-13.x.config.json
@@ -2,6 +2,6 @@
     "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "iPhone-11, 13.7",
+    "target": "^iPhone-11, 13.\\d$",
     "verbose": true
 }

--- a/conf/pr/local/ios-14.x.config.json
+++ b/conf/pr/local/ios-14.x.config.json
@@ -2,6 +2,6 @@
     "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "iPhone-12, 14.4",
+    "target": "^iPhone-12, 14.\\d$",
     "verbose": true
 }

--- a/conf/pr/local/ios-15.x.config.json
+++ b/conf/pr/local/ios-15.x.config.json
@@ -2,6 +2,6 @@
     "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "iPhone-13, 15.0",
+    "target": "^iPhone-13, 15.\\d$",
     "verbose": true
 }

--- a/lib/utils/utilities.js
+++ b/lib/utils/utilities.js
@@ -69,6 +69,7 @@ function getSimulatorModelId (cli, target) {
 
     const args = [
         'run',
+        'ios',
         '--list',
         '--emulator'
     ].concat(module.exports.PARAMEDIC_COMMON_ARGS);


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Cordova CLI 12.x requires platform name to be included with `cordova run --list` command

### Description
<!-- Describe your changes in detail -->

Added `ios` to the fetching of iOS run list.

### Testing
<!-- Please describe in detail how you tested your changes. -->

See GitHub Actions

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
