### PR TITLE
fix: correct name of iOS targets

### DIFF
--- a/conf/pr/local/ios-13.x.config.json
+++ b/conf/pr/local/ios-13.x.config.json
@@ -2,6 +2,6 @@
     "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "^iPhone-11, 13.\\d$",
+    "target": "iPhone-11, 13.\\d$",
     "verbose": true
 }

--- a/conf/pr/local/ios-14.x.config.json
+++ b/conf/pr/local/ios-14.x.config.json
@@ -2,6 +2,6 @@
     "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "^iPhone-12, 14.\\d$",
+    "target": "iPhone-12, 14.\\d$",
     "verbose": true
 }

--- a/conf/pr/local/ios-15.x.config.json
+++ b/conf/pr/local/ios-15.x.config.json
@@ -2,6 +2,6 @@
     "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "^iPhone-13, 15.\\d$",
+    "target": "iPhone-13, 15.\\d$",
     "verbose": true
 }

--- a/conf/pr/local/ios-16.x.config.json
+++ b/conf/pr/local/ios-16.x.config.json
@@ -2,6 +2,6 @@
     "platform": "ios@latest",
     "action": "run",
     "cleanUpAfterRun": true,
-    "target": "^iPhone-14, 16.\\d$",
+    "target": "iPhone-14, 16.\\d$",
     "verbose": true
 }


### PR DESCRIPTION
the `^` in the target names is making paramedic not find the devices when running the tests because the simulator names start with `\tiPhone`, not with `iPhone`