### PR TITLE
fix: Update file-transfer port

### DIFF
--- a/lib/PluginsManager.js
+++ b/lib/PluginsManager.js
@@ -52,7 +52,7 @@ class PluginsManager {
                     } else {
                         // no server address specified, starting a local server
                         const server = new Server(0, this.config.getExternalServerUrl());
-                        const fileServerUrl = server.getConnectionAddress(this.config.getPlatformId()) + ':5000';
+                        const fileServerUrl = server.getConnectionAddress(this.config.getPlatformId()) + ':5001';
                         additionalArgs += ' --variable FILETRANSFER_SERVER_ADDRESS=' + fileServerUrl;
                     }
                 }


### PR DESCRIPTION
since macOS monterrey, port 5000 is taken by control center, use 5001 instead

I don't think it affects the CI, but it's needed for local run of paramedic