### PR TITLE
fix: Finding first ios simulator

### DIFF
--- a/lib/utils/utilities.js
+++ b/lib/utils/utilities.js
@@ -94,7 +94,7 @@ function getSimulatorModelId (cli, target) {
     const matchingSimulators = allSimulators.filter(i => i.match(target));
     if (!matchingSimulators.length) {
         logger.warn('Unable to find requested simulator, falling back to the first available!');
-        return allSimulators.filter(i => i.match(/^iPhone/))[0].trim();
+        return allSimulators.filter(i => i.match(/iPhone/))[0].trim();
     }
     return matchingSimulators
         .pop()


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

simulator lists has a tab `\t`, so the `^` start of string regex was failing to find anything.

fixes #264 

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
