### PR TITLE
ci(android): set default java version to 17

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,7 +46,7 @@ jobs:
       # These are the default Java configurations used by most tests.
       # To customize these options, add "java-distro" or "java-version" to the strategy matrix with its overriding value.
       default_java-distro: temurin
-      default_java-version: 11
+      default_java-version: 17
 
       # These are the default Android System Image configurations used by most tests.
       # To customize these options, add "system-image-arch" or "system-image-target" to the strategy matrix with its overriding value.


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Use JDK 17 which is minimum requirement for latest `cordova-android` release

### Description
<!-- Describe your changes in detail -->

bump default java version to 1

### Testing
<!-- Please describe in detail how you tested your changes. -->

tested with file plugin

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
