### PR TITLE
fix: stabilize CI test harness for browser and Android cleanup

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -64,7 +64,7 @@ jobs:
 
           - os-version: macos-26
             ios-version: 26.x
-            xcode-version: 26.1
+            xcode-version: 26.x
 
     steps:
       - uses: actions/checkout@v6

--- a/conf/pr/local/browser.config.json
+++ b/conf/pr/local/browser.config.json
@@ -1,6 +1,7 @@
 {
     "platform": "browser@latest",
     "action": "run",
+    "target": "chrome",
     "cleanUpAfterRun": true,
     "verbose": true
 }

--- a/lib/LocalServer.js
+++ b/lib/LocalServer.js
@@ -157,6 +157,10 @@ class LocalServer extends EventEmitter {
         if (platform === utilities.ANDROID) {
             return '10.0.2.2';
         }
+        // Browser tests in CI (xvfb/headless chrome) are more reliable via localhost.
+        if (platform === utilities.BROWSER) {
+            return 'localhost';
+        }
         // iOS simulator/devices & Android device with reverse, or desktop
         return '127.0.0.1';
     }

--- a/lib/LocalServer.js
+++ b/lib/LocalServer.js
@@ -157,9 +157,9 @@ class LocalServer extends EventEmitter {
         if (platform === utilities.ANDROID) {
             return '10.0.2.2';
         }
-        // Browser tests in CI (xvfb/headless chrome) are more reliable via localhost.
+        // Browser target should prefer IPv4 loopback to avoid localhost -> ::1 resolution mismatches.
         if (platform === utilities.BROWSER) {
-            return 'localhost';
+            return '127.0.0.1';
         }
         // iOS simulator/devices & Android device with reverse, or desktop
         return '127.0.0.1';
@@ -244,7 +244,7 @@ function attemptToCreateServer () {
         const server = http.createServer();
         server.on('error', reject);
         server.on('listening', () => resolve(server));
-        server.listen(0, '0.0.0.0');
+        server.listen(0);
     });
 }
 

--- a/lib/LocalServer.js
+++ b/lib/LocalServer.js
@@ -244,7 +244,7 @@ function attemptToCreateServer () {
         const server = http.createServer();
         server.on('error', reject);
         server.on('listening', () => resolve(server));
-        server.listen(0);
+        server.listen(0, '127.0.0.1');
     });
 }
 

--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -84,7 +84,7 @@ class ParamedicApp {
      */
     async installPlugins () {
         const pluginsManager = new PluginsManager(this.tempFolder.name, this.storedCWD, this.config);
-        const ciFrameworkPlugins = ['github:apache/cordova-plugin-test-framework', path.join(__dirname, '..', 'paramedic-plugin')];
+        const ciFrameworkPlugins = ['github:GitToTheHub/cordova-plugin-test-framework', path.join(__dirname, '..', 'paramedic-plugin')];
 
         if (this.isIos) {
             ciFrameworkPlugins.push(path.join(__dirname, '..', 'ios-geolocation-permissions-plugin'));

--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -84,7 +84,7 @@ class ParamedicApp {
      */
     async installPlugins () {
         const pluginsManager = new PluginsManager(this.tempFolder.name, this.storedCWD, this.config);
-        const ciFrameworkPlugins = ['github:GitToTheHub/cordova-plugin-test-framework', path.join(__dirname, '..', 'paramedic-plugin')];
+        const ciFrameworkPlugins = ['github:apache/cordova-plugin-test-framework#pull/69/head', path.join(__dirname, '..', 'paramedic-plugin')];
 
         if (this.isIos) {
             ciFrameworkPlugins.push(path.join(__dirname, '..', 'ios-geolocation-permissions-plugin'));

--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -108,7 +108,11 @@ class ParamedicApp {
         logger.normal('[paramedic] Setting the app start page to the test page');
         const filePath = path.join(this.tempFolder.name, 'config.xml');
         let config = fs.readFileSync(filePath, utilities.DEFAULT_ENCODING);
-        config = config.replace('src="index.html"', 'src="cdvtests/index.html"');
+
+        // Browser platform serves from www root and may not expose cdvtests/index.html directly.
+        // Keep index.html for browser and use cdvtests/index.html for other platforms.
+        const startPage = this.isBrowser ? 'index.html' : 'cdvtests/index.html';
+        config = config.replace('src="index.html"', `src="${startPage}"`);
         fs.writeFileSync(filePath, config, utilities.DEFAULT_ENCODING);
     }
 

--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -151,10 +151,6 @@ class ParamedicApp {
         }
 
         const testPagePath = path.join(this.tempFolder.name, 'www', 'cdvtests', 'index.html');
-        if (!fs.existsSync(testPagePath)) {
-            return;
-        }
-
         const addrs = [
             'http://localhost:*',
             'http://127.0.0.1:*',
@@ -162,7 +158,16 @@ class ParamedicApp {
             'ws://127.0.0.1:*'
         ];
 
-        let html = fs.readFileSync(testPagePath, utilities.DEFAULT_ENCODING);
+        let html;
+        try {
+            html = fs.readFileSync(testPagePath, utilities.DEFAULT_ENCODING);
+        } catch (err) {
+            if (err && err.code === 'ENOENT') {
+                return;
+            }
+            throw err;
+        }
+
         const cspMetaRegex = /<meta[^>]+http-equiv=["']Content-Security-Policy["'][^>]*>/i;
         const cspContentRegex = /content=["']([^"']*)["']/i;
 
@@ -195,7 +200,14 @@ class ParamedicApp {
             }
         }
 
-        fs.writeFileSync(testPagePath, html, utilities.DEFAULT_ENCODING);
+        try {
+            fs.writeFileSync(testPagePath, html, utilities.DEFAULT_ENCODING);
+        } catch (err) {
+            if (err && err.code === 'ENOENT') {
+                return;
+            }
+            throw err;
+        }
     }
 
     /**

--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -33,6 +33,7 @@ class ParamedicApp {
         this.platformId = this.config.getPlatformId();
         this.isAndroid = this.platformId === utilities.ANDROID;
         this.isIos = this.platformId === utilities.IOS;
+        this.isBrowser = this.platformId === utilities.BROWSER;
 
         logger.info('---------------------------------------------------------');
         logger.info('1. Create Cordova app with platform and plugin(s) to test');
@@ -61,6 +62,7 @@ class ParamedicApp {
         return this.installPlatform()
             .then(() => this.installPlugins())
             .then(() => this.setUpStartPage())
+            .then(() => this.updateBrowserTestPageCSP())
             .then(() => this.checkPlatformRequirements())
             .then(() => this.checkDumpAndroidManifest())
             .then(() => this.checkDumpAndroidConfigXml());
@@ -108,6 +110,62 @@ class ParamedicApp {
         let config = fs.readFileSync(filePath, utilities.DEFAULT_ENCODING);
         config = config.replace('src="index.html"', 'src="cdvtests/index.html"');
         fs.writeFileSync(filePath, config, utilities.DEFAULT_ENCODING);
+    }
+
+    /**
+     * Ensures browser test page CSP allows localhost HTTP/WS endpoints used by Paramedic.
+     */
+    updateBrowserTestPageCSP () {
+        if (!this.isBrowser) {
+            return;
+        }
+
+        const testPagePath = path.join(this.tempFolder.name, 'www', 'cdvtests', 'index.html');
+        if (!fs.existsSync(testPagePath)) {
+            return;
+        }
+
+        const addrs = [
+            'http://localhost:*',
+            'http://127.0.0.1:*',
+            'ws://localhost:*',
+            'ws://127.0.0.1:*'
+        ];
+
+        let html = fs.readFileSync(testPagePath, utilities.DEFAULT_ENCODING);
+        const cspMetaRegex = /<meta[^>]+http-equiv=["']Content-Security-Policy["'][^>]*>/i;
+        const cspContentRegex = /content=["']([^"']*)["']/i;
+
+        if (cspMetaRegex.test(html)) {
+            html = html.replace(cspMetaRegex, (metaTag) => {
+                const contentMatch = metaTag.match(cspContentRegex);
+                if (!contentMatch) {
+                    return metaTag;
+                }
+
+                let cspContent = contentMatch[1];
+                const connectSrcRegex = /connect-src\s+([^;]+)/i;
+
+                if (connectSrcRegex.test(cspContent)) {
+                    cspContent = cspContent.replace(connectSrcRegex, (full, sources) => {
+                        const sourceSet = new Set(sources.trim().split(/\s+/).filter(Boolean));
+                        addrs.forEach((addr) => sourceSet.add(addr));
+                        return `connect-src ${Array.from(sourceSet).join(' ')}`;
+                    });
+                } else {
+                    cspContent = `${cspContent.trim().replace(/;?$/, ';')} connect-src 'self' ${addrs.join(' ')};`;
+                }
+
+                return metaTag.replace(cspContentRegex, `content="${cspContent}"`);
+            });
+        } else {
+            const cspTag = `<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; connect-src 'self' ${addrs.join(' ')};">`;
+            if (/<head[^>]*>/i.test(html)) {
+                html = html.replace(/<head[^>]*>/i, (headTag) => `${headTag}\n    ${cspTag}`);
+            }
+        }
+
+        fs.writeFileSync(testPagePath, html, utilities.DEFAULT_ENCODING);
     }
 
     /**

--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -61,6 +61,7 @@ class ParamedicApp {
     prepareProjectToRunTests () {
         return this.installPlatform()
             .then(() => this.installPlugins())
+            .then(() => this.ensureCdvTestsExists())
             .then(() => this.setUpStartPage())
             .then(() => this.updateBrowserTestPageCSP())
             .then(() => this.checkPlatformRequirements())
@@ -109,11 +110,36 @@ class ParamedicApp {
         const filePath = path.join(this.tempFolder.name, 'config.xml');
         let config = fs.readFileSync(filePath, utilities.DEFAULT_ENCODING);
 
-        // Browser platform serves from www root and may not expose cdvtests/index.html directly.
-        // Keep index.html for browser and use cdvtests/index.html for other platforms.
-        const startPage = this.isBrowser ? 'index.html' : 'cdvtests/index.html';
-        config = config.replace('src="index.html"', `src="${startPage}"`);
+        config = config.replace('src="index.html"', 'src="cdvtests/index.html"');
         fs.writeFileSync(filePath, config, utilities.DEFAULT_ENCODING);
+    }
+
+    /**
+     * For browser platform, explicitly copies cordova-plugin-test-framework assets to
+     * www/cdvtests/ because the Cordova <asset> element may not execute reliably on
+     * the browser platform in CI environments.
+     */
+    ensureCdvTestsExists () {
+        if (!this.isBrowser) {
+            return;
+        }
+
+        const tfPluginAssetsDir = path.join(this.tempFolder.name, 'plugins', 'cordova-plugin-test-framework', 'www', 'assets');
+        const cdvTestsDir = path.join(this.tempFolder.name, 'www', 'cdvtests');
+
+        if (!fs.existsSync(tfPluginAssetsDir)) {
+            logger.warn('[paramedic] cordova-plugin-test-framework assets not found at: ' + tfPluginAssetsDir);
+            return;
+        }
+
+        if (fs.existsSync(path.join(cdvTestsDir, 'index.html'))) {
+            logger.info('[paramedic] www/cdvtests/index.html already exists, skipping copy.');
+            return;
+        }
+
+        logger.info('[paramedic] Copying cordova-plugin-test-framework assets to www/cdvtests/');
+        fs.cpSync(tfPluginAssetsDir, cdvTestsDir, { recursive: true });
+        logger.info('[paramedic] Done copying to www/cdvtests/');
     }
 
     /**

--- a/lib/ParamedicApp.js
+++ b/lib/ParamedicApp.js
@@ -84,7 +84,7 @@ class ParamedicApp {
      */
     async installPlugins () {
         const pluginsManager = new PluginsManager(this.tempFolder.name, this.storedCWD, this.config);
-        const ciFrameworkPlugins = ['github:apache/cordova-plugin-test-framework#pull/69/head', path.join(__dirname, '..', 'paramedic-plugin')];
+        const ciFrameworkPlugins = ['github:apache/cordova-plugin-test-framework', path.join(__dirname, '..', 'paramedic-plugin')];
 
         if (this.isIos) {
             ciFrameworkPlugins.push(path.join(__dirname, '..', 'ios-geolocation-permissions-plugin'));

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -20,6 +20,7 @@
 const Server = require('./LocalServer');
 const path = require('path');
 const fs = require('fs');
+const { spawn } = require('node:child_process');
 const { setTimeout: timelimit } = require('node:timers/promises');
 
 const { logger, utilities, spawnAsync } = require('./utils');
@@ -284,6 +285,10 @@ class ParamedicRunner {
             });
         });
 
+        if (this.isBrowser) {
+            return await this.waitForBrowserTests(cmdArgs, testResults);
+        }
+
         // This spawns the Cordova run command. It will build, run, and trigger the automatic tests.
         await spawnAsync(
             this.config.getCli(),
@@ -292,6 +297,50 @@ class ParamedicRunner {
         );
 
         return testResults;
+    }
+
+    async waitForBrowserTests (cmdArgs, testResults) {
+        const browserRun = spawn(this.config.getCli(), cmdArgs, {
+            cwd: this.tempFolder.name,
+            stdio: 'pipe'
+        });
+
+        if (browserRun.stdout) {
+            browserRun.stdout.on('data', (data) => {
+                const text = data.toString();
+                if (this.config.isVerbose() && text.trim()) {
+                    logger.info(text.trimEnd());
+                }
+            });
+        }
+
+        if (browserRun.stderr) {
+            browserRun.stderr.on('data', (data) => {
+                const text = data.toString();
+                if (this.config.isVerbose() && text.trim()) {
+                    logger.warn(text.trimEnd());
+                }
+            });
+        }
+
+        const browserExit = new Promise((resolve, reject) => {
+            browserRun.on('error', reject);
+            browserRun.on('close', (code) => {
+                if (code === 0) {
+                    resolve();
+                } else {
+                    reject(new Error(`[paramedic] Browser run exited with code ${code} before tests completed`));
+                }
+            });
+        });
+
+        try {
+            return await Promise.race([testResults, browserExit]);
+        } finally {
+            if (!browserRun.killed) {
+                browserRun.kill('SIGINT');
+            }
+        }
     }
 
     /**

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -303,32 +303,30 @@ class ParamedicRunner {
 
             fallbackBrowserStarted = true;
 
-            const waitForReachableUrl = async (candidateUrls) => {
-                const urls = Array.from(new Set(candidateUrls.filter(Boolean)));
+            const waitForReachableUrl = async (candidateUrl) => {
                 const maxAttempts = 60;
                 const retryDelayMs = 500;
 
                 const canFetch = typeof fetch === 'function';
                 if (!canFetch) {
-                    return urls[0];
+                    return candidateUrl;
                 }
 
                 for (let attempt = 0; attempt < maxAttempts; attempt++) {
-                    for (const candidateUrl of urls) {
-                        try {
-                            const response = await fetch(candidateUrl, { redirect: 'follow' });
-                            if (response.ok) {
-                                return candidateUrl;
-                            }
-                        } catch {
-                            // Continue retrying until timeout.
+                    try {
+                        const response = await fetch(candidateUrl, { redirect: 'follow' });
+                        if (response.ok) {
+                            return candidateUrl;
                         }
+                    } catch {
+                        // Continue retrying until timeout.
                     }
 
                     await timelimit(retryDelayMs);
                 }
 
-                return urls[0];
+                logger.warn(`[paramedic] Start page was not reachable in time, launching anyway: ${candidateUrl}`);
+                return candidateUrl;
             };
 
             const chromeCmdCandidates = [
@@ -340,21 +338,14 @@ class ParamedicRunner {
             ].filter(Boolean);
 
             const tryLaunch = async () => {
-                let launchUrl = url;
-                try {
-                    const parsed = new URL(url);
-                    const rootUrl = `${parsed.protocol}//${parsed.host}/`;
-                    launchUrl = await waitForReachableUrl([url, rootUrl]);
-                } catch {
-                    launchUrl = await waitForReachableUrl([url]);
-                }
+                const launchUrl = await waitForReachableUrl(url);
 
                 const launchArgs = [
-                '--no-sandbox',
-                '--disable-gpu',
-                '--headless=new',
-                '--disable-dev-shm-usage',
-                '--autoplay-policy=no-user-gesture-required',
+                    '--no-sandbox',
+                    '--disable-gpu',
+                    '--headless=new',
+                    '--disable-dev-shm-usage',
+                    '--autoplay-policy=no-user-gesture-required',
                     launchUrl
                 ];
 

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -509,7 +509,11 @@ class ParamedicRunner {
         logger.info('[paramedic] Collecting Device Logs');
         const outputDir = this.config.getOutputDir() ? this.config.getOutputDir() : this.tempFolder.name;
         const paramedicLogCollector = new ParamedicLogCollector(this.config.getPlatformId(), this.tempFolder.name, outputDir, this.targetObj);
-        await paramedicLogCollector.collectLogs();
+        try {
+            await paramedicLogCollector.collectLogs();
+        } catch (err) {
+            logger.warn(`[paramedic] Unable to collect device logs, continuing cleanup: ${err.message}`);
+        }
     }
 
     uninstallApp () {

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -303,6 +303,34 @@ class ParamedicRunner {
 
             fallbackBrowserStarted = true;
 
+            const waitForReachableUrl = async (candidateUrls) => {
+                const urls = Array.from(new Set(candidateUrls.filter(Boolean)));
+                const maxAttempts = 60;
+                const retryDelayMs = 500;
+
+                const canFetch = typeof fetch === 'function';
+                if (!canFetch) {
+                    return urls[0];
+                }
+
+                for (let attempt = 0; attempt < maxAttempts; attempt++) {
+                    for (const candidateUrl of urls) {
+                        try {
+                            const response = await fetch(candidateUrl, { redirect: 'follow' });
+                            if (response.ok) {
+                                return candidateUrl;
+                            }
+                        } catch {
+                            // Continue retrying until timeout.
+                        }
+                    }
+
+                    await timelimit(retryDelayMs);
+                }
+
+                return urls[0];
+            };
+
             const chromeCmdCandidates = [
                 process.env.CHROME_BIN,
                 'google-chrome',
@@ -311,16 +339,26 @@ class ParamedicRunner {
                 'chromium'
             ].filter(Boolean);
 
-            const launchArgs = [
+            const tryLaunch = async () => {
+                let launchUrl = url;
+                try {
+                    const parsed = new URL(url);
+                    const rootUrl = `${parsed.protocol}//${parsed.host}/`;
+                    launchUrl = await waitForReachableUrl([url, rootUrl]);
+                } catch {
+                    launchUrl = await waitForReachableUrl([url]);
+                }
+
+                const launchArgs = [
                 '--no-sandbox',
                 '--disable-gpu',
                 '--headless=new',
                 '--disable-dev-shm-usage',
                 '--autoplay-policy=no-user-gesture-required',
-                url
-            ];
+                    launchUrl
+                ];
 
-            const tryLaunch = (idx) => {
+                const tryBinary = (idx) => {
                 if (idx >= chromeCmdCandidates.length) {
                     logger.warn('[paramedic] Unable to launch fallback Chrome (no known chrome binary found).');
                     return;
@@ -340,7 +378,7 @@ class ParamedicRunner {
 
                 proc.on('error', (err) => {
                     if (!launched && err && err.code === 'ENOENT') {
-                        tryLaunch(idx + 1);
+                        tryBinary(idx + 1);
                         return;
                     }
                     logger.warn(`[paramedic] Fallback browser error: ${err}`);
@@ -354,9 +392,12 @@ class ParamedicRunner {
                         }
                     });
                 }
+                };
+
+                tryBinary(0);
             };
 
-            tryLaunch(0);
+            void tryLaunch();
         };
 
         const browserRun = spawn(this.config.getCli(), cmdArgs, {

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -199,6 +199,18 @@ class ParamedicRunner {
         const medicFilePath = path.join(this.tempFolder.name, 'www', 'medic.json');
         const medicFileContent = JSON.stringify({ logurl: logUrl });
         fs.writeFileSync(medicFilePath, medicFileContent);
+
+        // Also pass logurl via start page query string for browser runs.
+        const configPath = path.join(this.tempFolder.name, 'config.xml');
+        if (fs.existsSync(configPath)) {
+            let config = fs.readFileSync(configPath, 'utf8');
+            const encodedLogUrl = encodeURIComponent(logUrl);
+            config = config.replace(
+                'src="cdvtests/index.html"',
+                `src="cdvtests/index.html?logurl=${encodedLogUrl}"`
+            );
+            fs.writeFileSync(configPath, config, 'utf8');
+        }
     }
 
     /**

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -300,6 +300,77 @@ class ParamedicRunner {
     }
 
     async waitForBrowserTests (cmdArgs, testResults) {
+        let fallbackBrowserProc = null;
+        let fallbackBrowserStarted = false;
+
+        const launchFallbackBrowser = (url) => {
+            if (fallbackBrowserStarted || process.env.CI !== 'true') {
+                return;
+            }
+
+            // Only needed for browser+chrome runs in CI where auto-open may be skipped.
+            if (this.config.getTarget() !== 'chrome') {
+                return;
+            }
+
+            fallbackBrowserStarted = true;
+
+            const chromeCmdCandidates = [
+                process.env.CHROME_BIN,
+                'google-chrome',
+                'google-chrome-stable',
+                'chromium-browser',
+                'chromium'
+            ].filter(Boolean);
+
+            const launchArgs = [
+                '--no-sandbox',
+                '--disable-gpu',
+                '--headless=new',
+                '--disable-dev-shm-usage',
+                '--autoplay-policy=no-user-gesture-required',
+                url
+            ];
+
+            const tryLaunch = (idx) => {
+                if (idx >= chromeCmdCandidates.length) {
+                    logger.warn('[paramedic] Unable to launch fallback Chrome (no known chrome binary found).');
+                    return;
+                }
+
+                const cmd = chromeCmdCandidates[idx];
+                logger.warn(`[paramedic] Launching fallback browser: ${cmd}`);
+
+                const proc = spawn(cmd, launchArgs, { stdio: 'pipe' });
+                let launched = false;
+
+                proc.on('spawn', () => {
+                    launched = true;
+                    fallbackBrowserProc = proc;
+                    logger.info('[paramedic] Fallback browser launched.');
+                });
+
+                proc.on('error', (err) => {
+                    if (!launched && err && err.code === 'ENOENT') {
+                        tryLaunch(idx + 1);
+                        return;
+                    }
+                    logger.warn(`[paramedic] Fallback browser error: ${err}`);
+                });
+
+                if (proc.stderr) {
+                    proc.stderr.on('data', (data) => {
+                        const text = data.toString();
+                        if (this.config.isVerbose() && text.trim()) {
+                            logger.warn(text.trimEnd());
+                        }
+                    });
+                }
+            };
+
+            tryLaunch(0);
+        };
+
         const browserRun = spawn(this.config.getCli(), cmdArgs, {
             cwd: this.tempFolder.name,
             stdio: 'pipe'
@@ -310,6 +381,11 @@ class ParamedicRunner {
                 const text = data.toString();
                 if (this.config.isVerbose() && text.trim()) {
                     logger.info(text.trimEnd());
+                }
+
+                const match = text.match(/Static file server running\s*@\s*(http:\/\/\S+)/i);
+                if (match && match[1]) {
+                    launchFallbackBrowser(match[1]);
                 }
             });
         }
@@ -339,6 +415,9 @@ class ParamedicRunner {
         } finally {
             if (!browserRun.killed) {
                 browserRun.kill('SIGINT');
+            }
+            if (fallbackBrowserProc && !fallbackBrowserProc.killed) {
+                fallbackBrowserProc.kill('SIGINT');
             }
         }
     }

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -200,18 +200,6 @@ class ParamedicRunner {
         const medicFilePath = path.join(this.tempFolder.name, 'www', 'medic.json');
         const medicFileContent = JSON.stringify({ logurl: logUrl });
         fs.writeFileSync(medicFilePath, medicFileContent);
-
-        // Also pass logurl via start page query string for browser runs.
-        const configPath = path.join(this.tempFolder.name, 'config.xml');
-        if (fs.existsSync(configPath)) {
-            let config = fs.readFileSync(configPath, 'utf8');
-            const encodedLogUrl = encodeURIComponent(logUrl);
-            config = config.replace(
-                'src="cdvtests/index.html"',
-                `src="cdvtests/index.html?logurl=${encodedLogUrl}"`
-            );
-            fs.writeFileSync(configPath, config, 'utf8');
-        }
     }
 
     /**

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -350,45 +350,47 @@ class ParamedicRunner {
                 ];
 
                 const tryBinary = (idx) => {
-                if (idx >= chromeCmdCandidates.length) {
-                    logger.warn('[paramedic] Unable to launch fallback Chrome (no known chrome binary found).');
-                    return;
-                }
-
-                const cmd = chromeCmdCandidates[idx];
-                logger.warn(`[paramedic] Launching fallback browser: ${cmd}`);
-
-                const proc = spawn(cmd, launchArgs, { stdio: 'pipe' });
-                let launched = false;
-
-                proc.on('spawn', () => {
-                    launched = true;
-                    fallbackBrowserProc = proc;
-                    logger.info('[paramedic] Fallback browser launched.');
-                });
-
-                proc.on('error', (err) => {
-                    if (!launched && err && err.code === 'ENOENT') {
-                        tryBinary(idx + 1);
+                    if (idx >= chromeCmdCandidates.length) {
+                        logger.warn('[paramedic] Unable to launch fallback Chrome (no known chrome binary found).');
                         return;
                     }
-                    logger.warn(`[paramedic] Fallback browser error: ${err}`);
-                });
 
-                if (proc.stderr) {
-                    proc.stderr.on('data', (data) => {
-                        const text = data.toString();
-                        if (this.config.isVerbose() && text.trim()) {
-                            logger.warn(text.trimEnd());
-                        }
+                    const cmd = chromeCmdCandidates[idx];
+                    logger.warn(`[paramedic] Launching fallback browser: ${cmd}`);
+
+                    const proc = spawn(cmd, launchArgs, { stdio: 'pipe' });
+                    let launched = false;
+
+                    proc.on('spawn', () => {
+                        launched = true;
+                        fallbackBrowserProc = proc;
+                        logger.info('[paramedic] Fallback browser launched.');
                     });
-                }
+
+                    proc.on('error', (err) => {
+                        if (!launched && err && err.code === 'ENOENT') {
+                            tryBinary(idx + 1);
+                            return;
+                        }
+                        logger.warn(`[paramedic] Fallback browser error: ${err}`);
+                    });
+
+                    if (proc.stderr) {
+                        proc.stderr.on('data', (data) => {
+                            const text = data.toString();
+                            if (this.config.isVerbose() && text.trim()) {
+                                logger.warn(text.trimEnd());
+                            }
+                        });
+                    }
                 };
 
                 tryBinary(0);
             };
 
-            void tryLaunch();
+            tryLaunch().catch((err) => {
+                logger.warn(`[paramedic] Fallback browser launch failed: ${err}`);
+            });
         };
 
         const browserRun = spawn(this.config.getCli(), cmdArgs, {

--- a/lib/paramedic.js
+++ b/lib/paramedic.js
@@ -276,7 +276,7 @@ class ParamedicRunner {
         await spawnAsync(
             this.config.getCli(),
             cmdArgs,
-            { cwd: this.tempFolder.name }
+            { cwd: this.tempFolder.name, verbose: this.config.isVerbose() }
         );
 
         return testResults;
@@ -295,8 +295,15 @@ class ParamedicRunner {
             ...utilities.PARAMEDIC_COMMON_ARGS
         ];
 
-        if (this.isBrowser || this.config.getAction() === 'build') {
+        if (this.config.getAction() === 'build') {
             return args;
+        }
+
+        if (this.isBrowser) {
+            const target = this.config.getTarget();
+            return target
+                ? [...args, '--target', target]
+                : args;
         }
 
         const targetChooser = new ParamedicTargetChooser(this.tempFolder.name, this.config);

--- a/lib/utils/spawn.js
+++ b/lib/utils/spawn.js
@@ -76,13 +76,21 @@ async function spawnAsync (cmd, args = [], options = {}) {
 
             if (proc.stdout) {
                 proc.stdout.on('data', (data) => {
-                    stdout += data.toString();
+                    const text = data.toString();
+                    stdout += text;
+                    if (verbose && text.trim()) {
+                        logger.info(text.trimEnd());
+                    }
                 });
             }
 
             if (proc.stderr) {
                 proc.stderr.on('data', (data) => {
-                    stderr += data.toString();
+                    const text = data.toString();
+                    stderr += text;
+                    if (verbose && text.trim()) {
+                        logger.warn(text.trimEnd());
+                    }
                 });
             }
 

--- a/paramedic-plugin/paramedic.js
+++ b/paramedic-plugin/paramedic.js
@@ -98,6 +98,17 @@ Paramedic.prototype.injectJasmineReporter = function () {
 };
 
 Paramedic.prototype.loadParamedicServerUrl = function () {
+    // First, allow passing logurl directly via query string to avoid path resolution issues.
+    try {
+        const url = new URL(window.location.href);
+        const queryLogUrl = url.searchParams.get('logurl');
+        if (queryLogUrl) {
+            return queryLogUrl;
+        }
+    } catch (ex) {
+        console.log('Unable to parse location for paramedic logurl: ' + ex);
+    }
+
     const candidates = [
         '../medic.json',
         './medic.json',

--- a/paramedic-plugin/paramedic.js
+++ b/paramedic-plugin/paramedic.js
@@ -98,15 +98,29 @@ Paramedic.prototype.injectJasmineReporter = function () {
 };
 
 Paramedic.prototype.loadParamedicServerUrl = function () {
-    try {
-        // attempt to synchronously load medic config
-        const xhr = new XMLHttpRequest();
-        xhr.open('GET', '../medic.json', false);
-        xhr.send(null);
-        const cfg = JSON.parse(xhr.responseText);
-        return cfg.logurl;
-    } catch (ex) {
-        console.log('Unable to load paramedic server url: ' + ex);
+    const candidates = [
+        '../medic.json',
+        './medic.json',
+        '/medic.json',
+        '../../medic.json'
+    ];
+
+    for (const candidate of candidates) {
+        try {
+            // attempt to synchronously load medic config
+            const xhr = new XMLHttpRequest();
+            xhr.open('GET', candidate, false);
+            xhr.send(null);
+
+            if (xhr.status >= 200 && xhr.status < 300 && xhr.responseText) {
+                const cfg = JSON.parse(xhr.responseText);
+                if (cfg && cfg.logurl) {
+                    return cfg.logurl;
+                }
+            }
+        } catch (ex) {
+            console.log(`Unable to load paramedic server url from ${candidate}: ${ex}`);
+        }
     }
 
     throw new Error('[paramedic] Failed to find logurl.');

--- a/paramedic-plugin/plugin.xml
+++ b/paramedic-plugin/plugin.xml
@@ -36,13 +36,17 @@
 
     <config-file target="config.xml" parent="/*">
       <access origin="http://127.0.0.1:*/*" />
+      <access origin="http://localhost:*/*" />
       <access origin="http://10.0.2.2:*/*" />
       <access origin="ws://127.0.0.1:*/*" />
+      <access origin="ws://localhost:*/*" />
 
       <allow-navigation href="http://127.0.0.1:*/*" />
+      <allow-navigation href="http://localhost:*/*" />
       <allow-navigation href="http://10.0.2.2:*/*" />
 
       <allow-intent href="http://127.0.0.1:*/*" />
+      <allow-intent href="http://localhost:*/*" />
       <allow-intent href="http://10.0.2.2:*/*" />
   </config-file>
 


### PR DESCRIPTION
## Summary

This PR ports the CI harness fixes validated in downstream plugin CI runs.

### Changes

- Ensure test framework assets are present under `www/cdvtests/` for browser runs when needed.
- Set start page to `cdvtests/index.html` for test execution.
- Keep browser test-page CSP compatible with `localhost`/`127.0.0.1` HTTP+WS endpoints used by Paramedic.
- Add a CI fallback launcher for headless Chrome when auto-open is skipped.
- Make device log collection best-effort so Android runs do not fail after successful Jasmine completion when `adb logcat` is unavailable during teardown.

## Motivation

Recent CI failures were caused by harness/start-page mismatches and post-test cleanup failures, not test logic regressions.

## Validation

- Browser matrix job passes with Jasmine specs executed and reported through the Paramedic WebSocket.
- Android matrix job no longer fails solely due to `adb logcat` teardown errors after successful specs.

## Downstream Validation

A dedicated downstream test PR is open in `apache/cordova-plugin-network-information`:
- https://github.com/apache/cordova-plugin-network-information/pull/184

That PR consumes this change chain and demonstrates successful CI runs.

Generated-By: GPT-5.3-Codex
