### PR TITLE
fix: use XCode version 26.x for iOS 26.x test instead of 26.1

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -64,7 +64,7 @@ jobs:
 
           - os-version: macos-26
             ios-version: 26.x
-            xcode-version: 26.1
+            xcode-version: 26.x
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

- iOS

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

- During testing PR #302, the iOS 26.x test did not succeed by the strange error message:  `xcodebuild: error: Unable to find a destination matching the provided destination specifier: { generic:1, platform:iOS Simulator }` and also later `iOS 26.1 is not installed. Please download and install the platform from Xcode > Settings > Components.`. After changing `xcode-version: 26.1` to `xcode-version: 26.x` XCode 26.5  was choosen and the error disappeared
- Failed test without the change: https://github.com/apache/cordova-paramedic/actions/runs/27076644293/job/79915055506?pr=302
- Sample successful test by PR #302: https://github.com/apache/cordova-paramedic/actions/runs/27077100277/job/79916245584?pr=302

### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
