### PR TITLE
chore(ios-permissions): defensive SQL escaping for TCC permission updates

### DIFF
--- a/lib/ParamediciOSPermissions.js
+++ b/lib/ParamediciOSPermissions.js
@@ -55,29 +55,33 @@ class ParamediciOSPermissions {
 
         for (const service of serviceList) {
             const app = this.appName;
+            const escapedService = service.replace(/'/g, "''");
+            const escapedApp = app.replace(/'/g, "''");
             // If the service has an entry already, the insert command will fail.
             // in this case we'll process with updating existing entry
+            const insertSQL = '"INSERT INTO access (service, client, client_type, allowed, prompt_count, csreq) VALUES(\'' + escapedService + '\', \'' + escapedApp + '\', 0, 1, 1, NULL)"';
             const insetProc = await spawnAsync(
                 'sqlite3',
                 [
                     destinationTCCFile,
-                    `"INSERT INTO access (service, client, client_type, allowed, prompt_count, csreq) VALUES('${service}', '${app}', 0, 1, 1, NULL)"`
+                    insertSQL
                 ]
             );
 
             if (insetProc.code) {
-                logger.warn(`[paramedic] Failed to insert permissions for ${app} into ${destinationTCCFile}. Will try to update existing permissions.`);
+                logger.warn('[paramedic] Failed to insert permissions for ' + app + ' into ' + destinationTCCFile + '. Will try to update existing permissions.');
 
+                const updateSQL = '"UPDATE access SET client_type=0, allowed=1, prompt_count=1, csreq=NULL WHERE service=\'' + escapedService + '\' AND client=\'' + escapedApp + '\'"';
                 const updateProc = await spawnAsync(
                     'sqlite3',
                     [
                         destinationTCCFile,
-                        `"UPDATE access SET client_type=0, allowed=1, prompt_count=1, csreq=NULL WHERE service='${service}' AND client='${app}'"`
+                        updateSQL
                     ]
                 );
 
                 if (updateProc.code) {
-                    logger.warn(`[paramedic] Failed to update existing permissions for ${app} into ${destinationTCCFile}. Continuing anyway.`);
+                    logger.warn('[paramedic] Failed to update existing permissions for ' + app + ' into ' + destinationTCCFile + '. Continuing anyway.');
                 }
             }
         }

--- a/lib/ParamediciOSPermissions.js
+++ b/lib/ParamediciOSPermissions.js
@@ -69,7 +69,7 @@ class ParamediciOSPermissions {
             );
 
             if (insetProc.code) {
-                logger.warn('[paramedic] Failed to insert permissions for ' + app + ' into ' + destinationTCCFile + '. Will try to update existing permissions.');
+                logger.warn(`[paramedic] Failed to insert permissions for ${app} into ${destinationTCCFile}. Will try to update existing permissions.`);
 
                 const updateSQL = '"UPDATE access SET client_type=0, allowed=1, prompt_count=1, csreq=NULL WHERE service=\'' + escapedService + '\' AND client=\'' + escapedApp + '\'"';
                 const updateProc = await spawnAsync(
@@ -81,7 +81,7 @@ class ParamediciOSPermissions {
                 );
 
                 if (updateProc.code) {
-                    logger.warn('[paramedic] Failed to update existing permissions for ' + app + ' into ' + destinationTCCFile + '. Continuing anyway.');
+                    logger.warn(`[paramedic] Failed to update existing permissions for ${app} into ${destinationTCCFile}. Continuing anyway.`);
                 }
             }
         }

--- a/lib/ParamediciOSPermissions.js
+++ b/lib/ParamediciOSPermissions.js
@@ -59,7 +59,7 @@ class ParamediciOSPermissions {
             const escapedApp = app.replace(/'/g, "''");
             // If the service has an entry already, the insert command will fail.
             // in this case we'll process with updating existing entry
-            const insertSQL = '"INSERT INTO access (service, client, client_type, allowed, prompt_count, csreq) VALUES(\'' + escapedService + '\', \'' + escapedApp + '\', 0, 1, 1, NULL)"';
+            const insertSQL = `"INSERT INTO access (service, client, client_type, allowed, prompt_count, csreq) VALUES('${escapedService}', '${escapedApp}', 0, 1, 1, NULL)"`;
             const insetProc = await spawnAsync(
                 'sqlite3',
                 [
@@ -71,7 +71,7 @@ class ParamediciOSPermissions {
             if (insetProc.code) {
                 logger.warn(`[paramedic] Failed to insert permissions for ${app} into ${destinationTCCFile}. Will try to update existing permissions.`);
 
-                const updateSQL = '"UPDATE access SET client_type=0, allowed=1, prompt_count=1, csreq=NULL WHERE service=\'' + escapedService + '\' AND client=\'' + escapedApp + '\'"';
+                const updateSQL = `"UPDATE access SET client_type=0, allowed=1, prompt_count=1, csreq=NULL WHERE service='${escapedService}' AND client='${escapedApp}'"`;
                 const updateProc = await spawnAsync(
                     'sqlite3',
                     [


### PR DESCRIPTION
## Summary
Fix a defence-in-depth security issue in `lib/ParamediciOSPermissions.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | MEDIUM |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `lib/ParamediciOSPermissions.js:60` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-89 |

**Description**: The ParamediciOSPermissions.js module constructs SQL INSERT and UPDATE statements using template literal string interpolation with the ${service} and ${app} variables. These variables are passed to the sqlite3 command-line tool without parameterisation or escaping, allowing SQL injection if an attacker controls these parameters.

## Evidence

**Exploitation scenario**: An attacker with filesystem write access to the iOS simulator directory or control over parameters passed to the ParamediciOSPermissions constructor could inject SQL metacharacters.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `lib/ParamediciOSPermissions.js`

## Behaviour Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
